### PR TITLE
Implements #31 - Generators available as extended

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 
 #![no_std]
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
@@ -124,6 +124,15 @@ pub const GENERATOR: AffinePoint = AffinePoint {
     ]),
 };
 
+/// [`GENERATOR`] in [`ExtendedPoint`] form
+pub const GENERATOR_EXTENDED: ExtendedPoint = ExtendedPoint {
+    x: GENERATOR.x,
+    y: GENERATOR.y,
+    z: Fq::one(),
+    t1: GENERATOR.x,
+    t2: GENERATOR.y,
+};
+
 /// GENERATOR NUMS which is obtained following the specs in:
 /// https://app.gitbook.com/@dusk-network/s/specs/specifications/poseidon/pedersen-commitment-scheme
 /// The counter = 18 and the hash function used to compute it was blake2b
@@ -143,6 +152,15 @@ pub const GENERATOR_NUMS: AffinePoint = AffinePoint {
         0x7b162dbeeb3b34fd,
         0x43d80eb3b2f3eb1b,
     ]),
+};
+
+/// [`GENERATOR_NUMS`] in [`ExtendedPoint`] form
+pub const GENERATOR_NUMS_EXTENDED: ExtendedPoint = ExtendedPoint {
+    x: GENERATOR_NUMS.x,
+    y: GENERATOR_NUMS.y,
+    z: Fq::one(),
+    t1: GENERATOR_NUMS.x,
+    t2: GENERATOR_NUMS.y,
 };
 
 // 202, 234, 123, 236, 255, 183, 247, 77, 237, 84, 108, 253, 33, 187, 62, 46,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1036,6 +1036,11 @@ fn test_affine_point_generator_has_order_p() {
 }
 
 #[test]
+fn test_extended_point_generator_has_order_p() {
+    assert_eq!(GENERATOR_EXTENDED.is_prime_order().unwrap_u8(), 1);
+}
+
+#[test]
 fn test_affine_point_generator_nums_has_order_p() {
     assert_eq!(GENERATOR_NUMS.is_prime_order().unwrap_u8(), 1);
 }
@@ -1044,6 +1049,14 @@ fn test_affine_point_generator_nums_has_order_p() {
 fn test_affine_point_generator_is_not_identity() {
     assert_ne!(
         ExtendedPoint::from(GENERATOR.mul_by_cofactor()),
+        ExtendedPoint::identity()
+    );
+}
+
+#[test]
+fn test_extended_point_generator_is_not_identity() {
+    assert_ne!(
+       GENERATOR_EXTENDED.mul_by_cofactor(),
         ExtendedPoint::identity()
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1056,7 +1056,7 @@ fn test_affine_point_generator_is_not_identity() {
 #[test]
 fn test_extended_point_generator_is_not_identity() {
     assert_ne!(
-       GENERATOR_EXTENDED.mul_by_cofactor(),
+        GENERATOR_EXTENDED.mul_by_cofactor(),
         ExtendedPoint::identity()
     );
 }


### PR DESCRIPTION
Every in-memory operation is performed with extended points, so the user
of the API will always need to convert the Affine Points to extend
before performing the operations.

To facilitate, we made available by default the generators also in
extended form.