### PR TITLE
Set blake2 as dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/dusk-network/jubjub"
 license = "MIT/Apache-2.0"
 name = "dusk-jubjub"
 repository = "https://github.com/dusk-network/jubjub"
-version = "0.8.1"
+version = "0.8.2"
 keywords = ["cryptography", "jubjub", "zk-snarks", "ecc", "elliptic-curve"]
 categories =["algorithms", "cryptography", "science"]
 edition = "2018"
@@ -19,7 +19,6 @@ exclude = [".github/workflows/ci.yml", "github/workflows/rust.yml",
 ]
 
 [dependencies]
-blake2 = "0.9"
 dusk-bytes = "0.1"
 dusk-bls12_381 = {version="0.6", default-features=false}
 subtle = {version="^2.3", default-features = false}
@@ -28,6 +27,7 @@ canonical = {version = "0.5", optional = true}
 canonical_derive = {version = "0.5", optional = true}
 
 [dev-dependencies]
+blake2 = "0.9"
 rand = "0.7"
 rand_xorshift = {version="0.2", default-features = false}
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# 0.8.2
+### Change
+- Issue #64 - Set blake2 to dev-dependency
+
 # 0.8.1
 ### Change
 - Issue #61 - Fix on default-features prop of dusk-bls12_381 dependency


### PR DESCRIPTION
Resolves #64
Blake2 is used only for tests and should not be a dependency of the library

It uses `std` and may impact on some `no-std` dependency tree