### PR TITLE
Add clippy job to CI workflow

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -1,71 +1,32 @@
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 name: Continuous integration
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+  code_analysis:
+    name: Code Analysis
+    uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
 
   test_nightly:
-      name: Nightly tests std
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-        - uses: actions-rs/cargo@v1
-          with:
-            command: test
-            args: --release
+    name: Nightly tests std
+    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
 
   build_nightly_nostd:
       name: Nightly build no_std
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal  
+        - uses: actions/checkout@v3
+        - uses: Swatinem/rust-cache@v2
         # ARM contains no std lib. Just core and alloc.
         - run: rustup target add thumbv6m-none-eabi
-        - uses: actions-rs/cargo@v1
-          with:
-            command: build
-            args: --release --no-default-features --target thumbv6m-none-eabi
-  
-  test_nightly_canon_feature:
-      name: Nightly tests canon
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-        - uses: actions-rs/cargo@v1
-          with:
-            command: test
-            args: --release --no-default-features --features canon
+        - run: cargo build --release --no-default-features --target thumbv6m-none-eabi
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+  test_nightly_canon_features:
+    name: Nightly tests canon
+    uses: dusk-network/.github/.github/workflows/run-tests.yml@main 
+    with:
+      test_flags: --no-default-features --features canon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add more tests for wnaf computation [#104]
+- Add a `clippy` action to CI and fix warnings [#91]
 
 ## [0.12.1] - 2022-10-19
 
@@ -182,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Initial fork from [`zkcrypto/jubjub`]
 
+[#91]: https://github.com/dusk-network/jubjub/issues/91
 [#104]: https://github.com/dusk-network/jubjub/issues/104
 [#95]: https://github.com/dusk-network/jubjub/issues/95
 [#93]: https://github.com/dusk-network/jubjub/issues/93

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2022-08-08
+nightly

--- a/src/elgamal.rs
+++ b/src/elgamal.rs
@@ -140,13 +140,28 @@ impl ElgamalCipher {
     pub fn decrypt(&self, secret: &JubJubScalar) -> JubJubExtended {
         self.delta - self.gamma * secret
     }
+
+    /// Add one Elgamal cipher to another.
+    pub fn add_ec(self, other: &ElgamalCipher) -> Self {
+        ElgamalCipher::new(self.gamma + other.gamma, self.delta + other.delta)
+    }
+
+    /// Subtract one Elgamal cipher from another.
+    pub fn sub_ec(self, other: &ElgamalCipher) -> Self {
+        ElgamalCipher::new(self.gamma - other.gamma, self.delta - other.delta)
+    }
+
+    /// Multiply an Elgamal cipher with a JubJub scalar.
+    pub fn mul_jjs(self, rhs: &JubJubScalar) -> ElgamalCipher {
+        ElgamalCipher::new(self.gamma * rhs, self.delta * rhs)
+    }
 }
 
 impl Add for &ElgamalCipher {
     type Output = ElgamalCipher;
 
     fn add(self, other: &ElgamalCipher) -> ElgamalCipher {
-        ElgamalCipher::new(self.gamma + other.gamma, self.delta + other.delta)
+        self.add_ec(other)
     }
 }
 
@@ -154,7 +169,7 @@ impl Add for ElgamalCipher {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        &self + &other
+        self.add_ec(&other)
     }
 }
 
@@ -168,7 +183,7 @@ impl Sub for &ElgamalCipher {
     type Output = ElgamalCipher;
 
     fn sub(self, other: &ElgamalCipher) -> ElgamalCipher {
-        ElgamalCipher::new(self.gamma - other.gamma, self.delta - other.delta)
+        self.sub_ec(other)
     }
 }
 
@@ -176,7 +191,7 @@ impl Sub for ElgamalCipher {
     type Output = Self;
 
     fn sub(self, other: Self) -> Self {
-        &self - &other
+        self.sub_ec(&other)
     }
 }
 
@@ -190,7 +205,7 @@ impl Mul<&JubJubScalar> for &ElgamalCipher {
     type Output = ElgamalCipher;
 
     fn mul(self, rhs: &JubJubScalar) -> ElgamalCipher {
-        ElgamalCipher::new(self.gamma * rhs, self.delta * rhs)
+        self.mul_jjs(rhs)
     }
 }
 
@@ -198,7 +213,7 @@ impl Mul<JubJubScalar> for &ElgamalCipher {
     type Output = ElgamalCipher;
 
     fn mul(self, rhs: JubJubScalar) -> ElgamalCipher {
-        self * &rhs
+        self.mul_jjs(&rhs)
     }
 }
 

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -53,8 +53,8 @@ impl From<u64> for Fr {
 impl From<i8> for Fr {
     fn from(val: i8) -> Fr {
         match (val >= 0, val < 0) {
-            (true, false) => Fr([val.abs() as u64, 0u64, 0u64, 0u64]),
-            (false, true) => -Fr([val.abs() as u64, 0u64, 0u64, 0u64]),
+            (true, false) => Fr([val.unsigned_abs() as u64, 0u64, 0u64, 0u64]),
+            (false, true) => -Fr([val.unsigned_abs() as u64, 0u64, 0u64, 0u64]),
             (_, _) => unreachable!(),
         }
     }
@@ -115,7 +115,7 @@ impl IndexMut<usize> for Fr {
 
 impl PartialOrd for Fr {
     fn partial_cmp(&self, other: &Fr) -> Option<Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 
@@ -123,12 +123,13 @@ impl Ord for Fr {
     fn cmp(&self, other: &Self) -> Ordering {
         let a = self;
         let other = other;
+
         for i in (0..4).rev() {
-            if a[i] > other[i] {
-                return Ordering::Greater;
-            } else if a[i] < other[i] {
-                return Ordering::Less;
-            }
+            match a[i].cmp(&other[i]) {
+                Ordering::Greater => return Ordering::Greater,
+                Ordering::Less => return Ordering::Less,
+                Ordering::Equal => continue,
+            };
         }
         Ordering::Equal
     }
@@ -431,8 +432,8 @@ impl Fr {
 
         CtOption::new(
             sqrt,
-            (&sqrt * &sqrt).ct_eq(self), /* Only return Some if it's the
-                                          * square root. */
+            (sqrt * sqrt).ct_eq(self), /* Only return Some if it's the
+                                        * square root. */
         )
     }
 
@@ -483,25 +484,25 @@ impl Fr {
         // found using https://github.com/kwantam/addchain
         let mut t1 = self.square();
         let mut t0 = t1.square();
-        let mut t3 = t0 * &t1;
+        let mut t3 = t0 * t1;
         let t6 = t3 * self;
-        let t7 = t6 * &t1;
-        let t12 = t7 * &t3;
-        let t13 = t12 * &t0;
-        let t16 = t12 * &t3;
-        let t2 = t13 * &t3;
-        let t15 = t16 * &t3;
-        let t19 = t2 * &t0;
-        let t9 = t15 * &t3;
-        let t18 = t9 * &t3;
-        let t14 = t18 * &t1;
-        let t4 = t18 * &t0;
-        let t8 = t18 * &t3;
-        let t17 = t14 * &t3;
-        let t11 = t8 * &t3;
-        t1 = t17 * &t3;
-        let t5 = t11 * &t3;
-        t3 = t5 * &t0;
+        let t7 = t6 * t1;
+        let t12 = t7 * t3;
+        let t13 = t12 * t0;
+        let t16 = t12 * t3;
+        let t2 = t13 * t3;
+        let t15 = t16 * t3;
+        let t19 = t2 * t0;
+        let t9 = t15 * t3;
+        let t18 = t9 * t3;
+        let t14 = t18 * t1;
+        let t4 = t18 * t0;
+        let t8 = t18 * t3;
+        let t17 = t14 * t3;
+        let t11 = t8 * t3;
+        t1 = t17 * t3;
+        let t5 = t11 * t3;
+        t3 = t5 * t0;
         t0 = t5.square();
         square_assign_multi(&mut t0, 5);
         t0.mul_assign(&t3);
@@ -577,6 +578,7 @@ impl Fr {
         CtOption::new(t0, !self.ct_eq(&Self::zero()))
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[inline]
     const fn montgomery_reduce(
         r0: u64,

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -369,7 +369,7 @@ impl Fr {
     /// Converts from an integer represented in little endian
     /// into its (congruent) `Fr` representation.
     pub const fn from_raw(val: [u64; 4]) -> Self {
-        (&Fr(val)).mul(&R2)
+        Fr(val).mul_fr(&R2)
     }
 
     /// Squares this element.
@@ -623,7 +623,7 @@ impl Fr {
         let (r7, _) = adc(r7, carry2, carry);
 
         // Result may be within MODULUS of the correct value
-        (&Fr([r4, r5, r6, r7])).sub(&MODULUS)
+        Fr([r4, r5, r6, r7]).sub_fr(&MODULUS)
     }
 
     /// Multiplies this element by another element
@@ -654,6 +654,12 @@ impl Fr {
         Fr::montgomery_reduce(r0, r1, r2, r3, r4, r5, r6, r7)
     }
 
+    /// Multiplies this element by another element. Proxy for [`fr::mul`].
+    #[inline]
+    pub const fn mul_fr(&self, rhs: &Self) -> Self {
+        self.mul(rhs)
+    }
+
     /// Subtracts another element from this element.
     #[inline]
     pub const fn sub(&self, rhs: &Self) -> Self {
@@ -673,6 +679,12 @@ impl Fr {
         Fr([d0, d1, d2, d3])
     }
 
+    /// Subtracts another element from this element. Proxy for [`fr::sub`].
+    #[inline]
+    pub const fn sub_fr(&self, rhs: &Self) -> Self {
+        self.sub(rhs)
+    }
+
     /// Adds this element to another element.
     #[inline]
     pub const fn add(&self, rhs: &Self) -> Self {
@@ -683,7 +695,13 @@ impl Fr {
 
         // Attempt to subtract the modulus, to ensure the value
         // is smaller than the modulus.
-        (&Fr([d0, d1, d2, d3])).sub(&MODULUS)
+        Fr([d0, d1, d2, d3]).sub_fr(&MODULUS)
+    }
+
+    /// Adds this element to another element. Proxy for [`fr::add`].
+    #[inline]
+    pub const fn add_fr(&self, rhs: &Self) -> Self {
+        self.add(rhs)
     }
 
     /// Negates this element.
@@ -705,6 +723,13 @@ impl Fr {
 
         Fr([d0 & mask, d1 & mask, d2 & mask, d3 & mask])
     }
+
+    /// Negates this element. Proxy for [`fr::neg`].
+    #[inline]
+    pub const fn neg_fr(&self) -> Self {
+        self.neg()
+    }
+
     /// Reduces bit representation of numbers, such that
     /// they can be evaluated in terms of the least significant bit.
     pub fn reduce(&self) -> Self {
@@ -764,7 +789,7 @@ impl Fr {
             if !k.is_even() {
                 let ki = k.mods_2_pow_k(width);
                 res[i] = ki;
-                k = k - Fr::from(ki);
+                k -= Fr::from(ki);
             } else {
                 res[i] = 0i8;
             };


### PR DESCRIPTION
Resolves #91  

The `-D warnings` argument treats Clippy warnings as errors. The  job will thus fail if any Clippy warnings are found. This might be too stringent for now, given there's about 95 warnings on this repository.

Either we make it less stringent for now or the warnings should be resolved before merging this PR.