### PR TITLE
Take upstream impls and segregate modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-
-- Remove `canonical` and `canonical_derive` dependency [#109]
-
 ### Added
 
 - Add more tests for wnaf computation [#104]
+
+### Changed
+
+- Merge upstream changes from `zkcrypto` [#115]
+
+### Removed
+
+- Remove `canonical` and `canonical_derive` dependency [#109]
 
 ## [0.12.1] - 2022-10-19
 
@@ -186,6 +190,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Initial fork from [`zkcrypto/jubjub`]
 
+[#115]: https://github.com/dusk-network/jubjub/issues/115
 [#109]: https://github.com/dusk-network/jubjub/issues/109
 [#104]: https://github.com/dusk-network/jubjub/issues/104
 [#95]: https://github.com/dusk-network/jubjub/issues/95

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
     "CPerezz <carlos@dusk.network>"
 ]
 description = "Dusk's fork of the implementation of the Jubjub elliptic curve group"
+documentation = "https://docs.rs/dusk-jubjub"
 homepage = "https://github.com/dusk-network/jubjub"
 license = "MIT/Apache-2.0"
 name = "dusk-jubjub"
@@ -14,23 +15,73 @@ version = "0.12.1"
 keywords = ["cryptography", "jubjub", "zk-snarks", "ecc", "elliptic-curve"]
 categories =["algorithms", "cryptography", "science", "no-std"]
 edition = "2021"
-exclude = [".github/workflows/ci.yml", "github/workflows/rust.yml",
-".gitignore", 
+exclude = [
+    ".github/*",
+    ".gitignore",
 ]
 
-[dependencies]
-dusk-bytes = "0.1"
-dusk-bls12_381 = {version="0.11", default-features=false}
-subtle = {version="^2.3", default-features = false}
-rand_core = {version = "0.6", default-features=false}
-rkyv = {version = "0.7", optional = true, default-features = false}
-bytecheck = {version = "0.6", optional=true, default-features = false}
+[dependencies.bitvec]
+version = "1"
+default-features = false
+
+[dependencies.bytecheck]
+version = "0.6"
+optional = true
+default-features = false
+
+[dependencies.dusk-bls12_381]
+version = "0.12"
+default-features = false
+
+[dependencies.dusk-bytes]
+version = "0.1"
+
+[dependencies.ff]
+version = "0.13"
+default-features = false
+
+[dependencies.group]
+version = "0.13"
+default-features = false
+
+[dependencies.rand_core]
+version = "0.6"
+default-features = false
+
+[dependencies.rkyv]
+version = "0.7"
+optional = true
+default-features = false
+
+[dependencies.subtle]
+version = "^2.2.1"
+default-features = false
 
 [dev-dependencies]
-rand_xorshift = {version="0.3", default-features = false}
-blake2 = "0.9"
+criterion = "0.3"
+csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
+
+[dev-dependencies.rand_xorshift]
+version = "0.3"
+default-features = false
+
+[dev-dependencies.blake2]
+version = "0.9"
 
 [features]
-default = ["std"]
-std = ["dusk-bls12_381/default"]
+default = ["alloc", "bits"]
+alloc = ["ff/alloc", "group/alloc"]
+bits = ["ff/bits"]
 rkyv-impl = ["bytecheck", "dusk-bls12_381/rkyv-impl", "rkyv"]
+
+[[bench]]
+name = "fq_bench"
+harness = false
+
+[[bench]]
+name = "fr_bench"
+harness = false
+
+[[bench]]
+name = "point_bench"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,17 +24,9 @@ exclude = [
 version = "1"
 default-features = false
 
-[dependencies.bytecheck]
-version = "0.6"
-optional = true
-default-features = false
-
 [dependencies.dusk-bls12_381]
 version = "0.12"
 default-features = false
-
-[dependencies.dusk-bytes]
-version = "0.1"
 
 [dependencies.ff]
 version = "0.13"
@@ -48,14 +40,24 @@ default-features = false
 version = "0.6"
 default-features = false
 
+[dependencies.subtle]
+version = "^2.2.1"
+default-features = false
+
+# Begin Dusk dependencies
+[dependencies.bytecheck]
+version = "0.6"
+optional = true
+default-features = false
+
+[dependencies.dusk-bytes]
+version = "0.1"
+
 [dependencies.rkyv]
 version = "0.7"
 optional = true
 default-features = false
-
-[dependencies.subtle]
-version = "^2.2.1"
-default-features = false
+# End Dusk dependendencies
 
 [dev-dependencies]
 criterion = "0.3"
@@ -65,6 +67,7 @@ csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
 version = "0.3"
 default-features = false
 
+# Begin Dusk dev-dependencies
 [dev-dependencies.blake2]
 version = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ version = "0.6"
 default-features = false
 
 [dependencies.subtle]
-version = "^2.2.1"
+version = "2"
 default-features = false
 
 # Begin Dusk dependencies

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jubjub [![Crates.io](https://img.shields.io/crates/v/jubjub.svg)](https://crates.io/crates/jubjub) #
+# jubjub [![Crates.io](https://img.shields.io/crates/v/jubjub.svg)](https://crates.io/crates/dusk-jubjub) #
 
 <img
  width="15%"
@@ -8,7 +8,7 @@
 This is a pure Rust implementation of the Jubjub elliptic curve group and its associated fields.
 
 * **This implementation has not been reviewed or audited. Use at your own risk.**
-* This implementation targets Rust `1.36` or later.
+* This implementation targets Rust `1.56` or later.
 * All operations are constant time unless explicitly noted.
 * This implementation does not require the Rust standard library.
 

--- a/benches/fq_bench.rs
+++ b/benches/fq_bench.rs
@@ -1,0 +1,58 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use dusk_jubjub::*;
+
+fn bench_add_assign(c: &mut Criterion) {
+    let mut n = Fq::one();
+    let neg_one = -Fq::one();
+    c.bench_function("Fq add_assign", |b| {
+        b.iter(move || {
+            n += &neg_one;
+        })
+    });
+}
+
+fn bench_sub_assign(c: &mut Criterion) {
+    let mut n = Fq::one();
+    let neg_one = -Fq::one();
+    c.bench_function("Fq sub_assign", |b| {
+        b.iter(move || {
+            n -= &neg_one;
+        })
+    });
+}
+
+fn bench_mul_assign(c: &mut Criterion) {
+    let mut n = Fq::one();
+    let neg_one = -Fq::one();
+    c.bench_function("Fq mul_assign", |b| {
+        b.iter(move || {
+            n *= &neg_one;
+        })
+    });
+}
+
+fn bench_square(c: &mut Criterion) {
+    let n = Fq::one();
+    c.bench_function("Fq square", |b| b.iter(move || n.square()));
+}
+
+fn bench_invert(c: &mut Criterion) {
+    let n = Fq::one();
+    c.bench_function("Fq invert", |b| b.iter(move || n.invert()));
+}
+
+fn bench_sqrt(c: &mut Criterion) {
+    let n = Fq::one().double().double();
+    c.bench_function("Fq sqrt", |b| b.iter(move || n.sqrt()));
+}
+
+criterion_group!(
+    benches,
+    bench_add_assign,
+    bench_sub_assign,
+    bench_mul_assign,
+    bench_square,
+    bench_invert,
+    bench_sqrt,
+);
+criterion_main!(benches);

--- a/benches/fr_bench.rs
+++ b/benches/fr_bench.rs
@@ -1,0 +1,58 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use dusk_jubjub::*;
+
+fn bench_add_assign(c: &mut Criterion) {
+    let mut n = Fr::one();
+    let neg_one = -Fr::one();
+    c.bench_function("Fr add_assign", |b| {
+        b.iter(move || {
+            n += &neg_one;
+        })
+    });
+}
+
+fn bench_sub_assign(c: &mut Criterion) {
+    let mut n = Fr::one();
+    let neg_one = -Fr::one();
+    c.bench_function("Fr sub_assign", |b| {
+        b.iter(move || {
+            n -= &neg_one;
+        })
+    });
+}
+
+fn bench_mul_assign(c: &mut Criterion) {
+    let mut n = Fr::one();
+    let neg_one = -Fr::one();
+    c.bench_function("Fr mul_assign", |b| {
+        b.iter(move || {
+            n *= &neg_one;
+        })
+    });
+}
+
+fn bench_square(c: &mut Criterion) {
+    let n = Fr::one();
+    c.bench_function("Fr square", |b| b.iter(move || n.square()));
+}
+
+fn bench_invert(c: &mut Criterion) {
+    let n = Fr::one();
+    c.bench_function("Fr invert", |b| b.iter(move || n.invert()));
+}
+
+fn bench_sqrt(c: &mut Criterion) {
+    let n = Fr::one().double().double();
+    c.bench_function("Fr sqrt", |b| b.iter(move || n.sqrt()));
+}
+
+criterion_group!(
+    benches,
+    bench_add_assign,
+    bench_sub_assign,
+    bench_mul_assign,
+    bench_square,
+    bench_invert,
+    bench_sqrt,
+);
+criterion_main!(benches);

--- a/benches/point_bench.rs
+++ b/benches/point_bench.rs
@@ -1,0 +1,73 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use dusk_jubjub::*;
+
+// Non-Niels
+
+fn bench_point_doubling(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    c.bench_function("Jubjub point doubling", |bencher| {
+        bencher.iter(move || a.double())
+    });
+}
+
+fn bench_point_addition(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    let b = -ExtendedPoint::identity();
+    c.bench_function("Jubjub point addition", |bencher| {
+        bencher.iter(move || a + b)
+    });
+}
+
+fn bench_point_subtraction(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    let b = -ExtendedPoint::identity();
+    c.bench_function("Jubjub point subtraction", |bencher| {
+        bencher.iter(move || a + b)
+    });
+}
+
+// Niels
+
+fn bench_cached_point_addition(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    let b = ExtendedPoint::identity().to_niels();
+    c.bench_function("Jubjub cached point addition", |bencher| {
+        bencher.iter(move || a + b)
+    });
+}
+
+fn bench_cached_point_subtraction(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    let b = ExtendedPoint::identity().to_niels();
+    c.bench_function("Jubjub cached point subtraction", |bencher| {
+        bencher.iter(move || a + b)
+    });
+}
+
+fn bench_cached_affine_point_addition(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    let b = AffinePoint::identity().to_niels();
+    c.bench_function("Jubjub cached affine point addition", |bencher| {
+        bencher.iter(move || a + b)
+    });
+}
+
+fn bench_cached_affine_point_subtraction(c: &mut Criterion) {
+    let a = ExtendedPoint::identity();
+    let b = AffinePoint::identity().to_niels();
+    c.bench_function("Jubjub cached affine point subtraction", |bencher| {
+        bencher.iter(move || a + b)
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_point_doubling,
+    bench_point_addition,
+    bench_point_subtraction,
+    bench_cached_point_addition,
+    bench_cached_point_subtraction,
+    bench_cached_affine_point_addition,
+    bench_cached_affine_point_subtraction,
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,17 @@
 //! This crate provides an implementation of the **Jubjub** elliptic curve and
-//! its associated field arithmetic.
-//! See [`README.md`](https://github.com/zkcrypto/jubjub/blob/master/README.md)
-// for more details about Jubjub.
+//! its associated field arithmetic. See [`README.md`](https://github.com/dusk-network/jubjub/blob/master/README.md) for more details about Jubjub.
 //!
 //! # API
 //!
-//! * `JubJubAffine` / `JubJubExtended` which are implementations of Jubjub
-//!   group arithmetic
+//! * `AffinePoint` / `ExtendedPoint` which are implementations of Jubjub group
+//!   arithmetic
 //! * `AffineNielsPoint` / `ExtendedNielsPoint` which are pre-processed Jubjub
 //!   points
-//! * `BlsScalar`, which is the base field of Jubjub
+//! * `Fq`, which is the base field of Jubjub
 //! * `Fr`, which is the scalar field of Jubjub
-//! * `batch_normalize` for converting many `JubJubExtended`s into
-//!   `JubJubAffine`s efficiently.
+//! * `batch_normalize` for converting many `ExtendedPoint`s into `AffinePoint`s
+//!   efficiently.
+//! * `JubJubAffine` / `JubJubExtended` as convenient type aliases.
 //!
 //! # Constant Time
 //!
@@ -22,7 +21,7 @@
 //!
 //! This crate uses the `subtle` crate to perform constant-time operations.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
@@ -34,32 +33,46 @@
 // binary operators, and so this lint is triggered unnecessarily.
 #![allow(clippy::suspicious_arithmetic_impl)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[cfg(test)]
 #[macro_use]
 extern crate std;
 
+use bitvec::{order::Lsb0, view::AsBits};
+use core::borrow::Borrow;
+use core::fmt;
+use core::iter::Sum;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use dusk_bytes::{Error as BytesError, Serializable};
+use ff::{BatchInverter, Field};
+use group::{
+    cofactor::{CofactorCurve, CofactorCurveAffine, CofactorGroup},
+    prime::PrimeGroup,
+    Curve, Group, GroupEncoding,
+};
+use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-#[cfg(feature = "rkyv-impl")]
-use bytecheck::CheckBytes;
-#[cfg(feature = "rkyv-impl")]
-use rkyv::{Archive, Deserialize, Serialize};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "alloc")]
+use group::WnafGroup;
 
 #[macro_use]
 mod util;
+
 mod fr;
+pub use dusk_bls12_381::BlsScalar as Fq;
+pub use fr::Fr;
 
-/// Implementation of ElGamal encryption scheme with JubJub
-pub mod elgamal;
+/// Represents an element of the base field $\mathbb{F}_q$ of the Jubjub
+/// elliptic curve construction.
+pub type Base = Fq;
 
-pub use dusk_bls12_381::BlsScalar;
-pub use fr::Fr as JubJubScalar;
-
-pub(crate) use fr::Fr;
-
-/// A better name than Fr.
+/// Represents an element of the scalar field $\mathbb{F}_r$ of the Jubjub
+/// elliptic curve construction.
 pub type Scalar = Fr;
 
 const FR_MODULUS_BYTES: [u8; 32] = [
@@ -67,184 +80,144 @@ const FR_MODULUS_BYTES: [u8; 32] = [
     0, 59, 52, 1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14,
 ];
 
-/// This represents a Jubjub point in the affine `(x, y)`
+/// This represents a Jubjub point in the affine `(u, v)`
 /// coordinates.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "rkyv-impl", derive(Archive, Serialize, Deserialize))]
-#[cfg_attr(feature = "rkyv-impl", archive_attr(derive(CheckBytes)))]
-pub struct JubJubAffine {
-    x: BlsScalar,
-    y: BlsScalar,
+#[derive(Clone, Copy, Debug, Eq)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct AffinePoint {
+    u: Fq,
+    v: Fq,
 }
 
-impl Neg for JubJubAffine {
-    type Output = JubJubAffine;
+impl fmt::Display for AffinePoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
 
-    /// This computes the negation of a point `P = (x, y)`
-    /// as `-P = (-x, y)`.
+impl Neg for AffinePoint {
+    type Output = AffinePoint;
+
+    /// This computes the negation of a point `P = (u, v)`
+    /// as `-P = (-u, v)`.
     #[inline]
-    fn neg(self) -> JubJubAffine {
-        JubJubAffine {
-            x: -self.x,
-            y: self.y,
+    fn neg(self) -> AffinePoint {
+        AffinePoint {
+            u: -self.u,
+            v: self.v,
         }
     }
 }
 
-impl ConstantTimeEq for JubJubAffine {
+impl ConstantTimeEq for AffinePoint {
     fn ct_eq(&self, other: &Self) -> Choice {
-        self.x.ct_eq(&other.x) & self.y.ct_eq(&other.y)
+        self.u.ct_eq(&other.u) & self.v.ct_eq(&other.v)
     }
 }
 
-impl PartialEq for JubJubAffine {
+impl PartialEq for AffinePoint {
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
-impl ConditionallySelectable for JubJubAffine {
+impl ConditionallySelectable for AffinePoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        JubJubAffine {
-            x: BlsScalar::conditional_select(&a.x, &b.x, choice),
-            y: BlsScalar::conditional_select(&a.y, &b.y, choice),
+        AffinePoint {
+            u: Fq::conditional_select(&a.u, &b.u, choice),
+            v: Fq::conditional_select(&a.v, &b.v, choice),
         }
     }
 }
 
-/// Use a fixed generator point.
-/// The point is then reduced according to the prime field. We need only to
-/// state the coordinates, so users can exploit its properties
-/// which are proven by tests, checking:
-/// - It lies on the curve,
-/// - Is of prime order,
-/// - Is not the identity point.
-/// Using:
-///     x = 0x3fd2814c43ac65a6f1fbf02d0fd6cce62e3ebb21fd6c54ed4df7b7ffec7beaca
-//      y = 0x0000000000000000000000000000000000000000000000000000000000000012
-pub const GENERATOR: JubJubAffine = JubJubAffine {
-    x: BlsScalar::from_raw([
-        0x4df7b7ffec7beaca,
-        0x2e3ebb21fd6c54ed,
-        0xf1fbf02d0fd6cce6,
-        0x3fd2814c43ac65a6,
-    ]),
-    y: BlsScalar::from_raw([
-        0x0000000000000012,
-        000000000000000000,
-        000000000000000000,
-        000000000000,
-    ]),
-};
-
-/// [`GENERATOR`] in [`JubJubExtended`] form
-pub const GENERATOR_EXTENDED: JubJubExtended = JubJubExtended {
-    x: GENERATOR.x,
-    y: GENERATOR.y,
-    z: BlsScalar::one(),
-    t1: GENERATOR.x,
-    t2: GENERATOR.y,
-};
-
-/// GENERATOR NUMS which is obtained following the specs in:
-/// https://app.gitbook.com/@dusk-network/s/specs/specifications/poseidon/pedersen-commitment-scheme
-/// The counter = 18 and the hash function used to compute it was blake2b
-/// Using:
-///     x = 0x5e67b8f316f414f7bd9514c773fd4456931e316a39fe4541921710179df76377
-//      y = 0x43d80eb3b2f3eb1b7b162dbeeb3b34fd9949ba0f82a5507a6705b707162e3ef8
-pub const GENERATOR_NUMS: JubJubAffine = JubJubAffine {
-    x: BlsScalar::from_raw([
-        0x921710179df76377,
-        0x931e316a39fe4541,
-        0xbd9514c773fd4456,
-        0x5e67b8f316f414f7,
-    ]),
-    y: BlsScalar::from_raw([
-        0x6705b707162e3ef8,
-        0x9949ba0f82a5507a,
-        0x7b162dbeeb3b34fd,
-        0x43d80eb3b2f3eb1b,
-    ]),
-};
-
-/// [`GENERATOR_NUMS`] in [`JubJubExtended`] form
-pub const GENERATOR_NUMS_EXTENDED: JubJubExtended = JubJubExtended {
-    x: GENERATOR_NUMS.x,
-    y: GENERATOR_NUMS.y,
-    z: BlsScalar::one(),
-    t1: GENERATOR_NUMS.x,
-    t2: GENERATOR_NUMS.y,
-};
-
-// 202, 234, 123, 236, 255, 183, 247, 77, 237, 84, 108, 253, 33, 187, 62, 46,
-// 230, 204, 214,15, 45, 240, 251, 241, 166, 101, 172, 67, 76, 129, 210, 63,
-
-// 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-// 0, 0, 0, 0, 0, 0, 0,
-
-/// This represents an extended point `(X, Y, Z, T1, T2)`
+/// This represents an extended point `(U, V, Z, T1, T2)`
 /// with `Z` nonzero, corresponding to the affine point
-/// `(X/Z, Y/Z)`. We always have `T1 * T2 = XY/Z`.
+/// `(U/Z, V/Z)`. We always have `T1 * T2 = UV/Z`.
 ///
 /// You can do the following things with a point in this
 /// form:
 ///
 /// * Convert it into a point in the affine form.
-/// * Add it to an `JubJubExtended`, `AffineNielsPoint` or `ExtendedNielsPoint`.
+/// * Add it to an `ExtendedPoint`, `AffineNielsPoint` or `ExtendedNielsPoint`.
 /// * Double it using `double()`.
 /// * Compare it with another extended point using `PartialEq` or `ct_eq()`.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "rkyv-impl", derive(Archive, Serialize, Deserialize))]
-#[cfg_attr(feature = "rkyv-impl", archive_attr(derive(CheckBytes)))]
-pub struct JubJubExtended {
-    x: BlsScalar,
-    y: BlsScalar,
-    z: BlsScalar,
-    t1: BlsScalar,
-    t2: BlsScalar,
+#[derive(Clone, Copy, Debug, Eq)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct ExtendedPoint {
+    u: Fq,
+    v: Fq,
+    z: Fq,
+    t1: Fq,
+    t2: Fq,
 }
 
-impl ConstantTimeEq for JubJubExtended {
-    fn ct_eq(&self, other: &Self) -> Choice {
-        // (x/z, y/z) = (x'/z', y'/z') is implied by
-        //      (xz'z = x'z'z) and
-        //      (yz'z = y'z'z)
-        // as z and z' are always nonzero.
-
-        (&self.x * &other.z).ct_eq(&(&other.x * &self.z))
-            & (&self.y * &other.z).ct_eq(&(&other.y * &self.z))
+impl fmt::Display for ExtendedPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
-impl ConditionallySelectable for JubJubExtended {
+impl ConstantTimeEq for ExtendedPoint {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        // (u/z, v/z) = (u'/z', v'/z') is implied by
+        //      (uz'z = u'z'z) and
+        //      (vz'z = v'z'z)
+        // as z and z' are always nonzero.
+
+        (self.u * other.z).ct_eq(&(other.u * self.z))
+            & (self.v * other.z).ct_eq(&(other.v * self.z))
+    }
+}
+
+impl ConditionallySelectable for ExtendedPoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
-        JubJubExtended {
-            x: BlsScalar::conditional_select(&a.x, &b.x, choice),
-            y: BlsScalar::conditional_select(&a.y, &b.y, choice),
-            z: BlsScalar::conditional_select(&a.z, &b.z, choice),
-            t1: BlsScalar::conditional_select(&a.t1, &b.t1, choice),
-            t2: BlsScalar::conditional_select(&a.t2, &b.t2, choice),
+        ExtendedPoint {
+            u: Fq::conditional_select(&a.u, &b.u, choice),
+            v: Fq::conditional_select(&a.v, &b.v, choice),
+            z: Fq::conditional_select(&a.z, &b.z, choice),
+            t1: Fq::conditional_select(&a.t1, &b.t1, choice),
+            t2: Fq::conditional_select(&a.t2, &b.t2, choice),
         }
     }
 }
 
-impl PartialEq for JubJubExtended {
+impl PartialEq for ExtendedPoint {
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(other).unwrap_u8() == 1
+        bool::from(self.ct_eq(other))
     }
 }
 
-impl Neg for JubJubExtended {
-    type Output = JubJubExtended;
+impl<T> Sum<T> for ExtendedPoint
+where
+    T: Borrow<ExtendedPoint>,
+{
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T>,
+    {
+        iter.fold(Self::identity(), |acc, item| acc + item.borrow())
+    }
+}
 
-    /// Computes the negation of a point `P = (X, Y, Z, T)`
-    /// as `-P = (-X, Y, Z, -T1, T2)`. The choice of `T1`
+impl Neg for ExtendedPoint {
+    type Output = ExtendedPoint;
+
+    /// Computes the negation of a point `P = (U, V, Z, T)`
+    /// as `-P = (-U, V, Z, -T1, T2)`. The choice of `T1`
     /// is made without loss of generality.
     #[inline]
-    fn neg(self) -> JubJubExtended {
-        JubJubExtended {
-            x: -self.x,
-            y: self.y,
+    fn neg(self) -> ExtendedPoint {
+        ExtendedPoint {
+            u: -self.u,
+            v: self.v,
             z: self.z,
             t1: -self.t1,
             t2: self.t2,
@@ -252,63 +225,74 @@ impl Neg for JubJubExtended {
     }
 }
 
-impl From<JubJubAffine> for JubJubExtended {
-    fn from(affine: JubJubAffine) -> JubJubExtended {
-        Self::from_affine(affine)
-    }
-}
-
-impl<'a> From<&'a JubJubExtended> for JubJubAffine {
-    /// Constructs an affine point from an extended point
-    /// using the map `(X, Y, Z, T1, T2) => (XZ, Y/Z)`
-    /// as Z is always nonzero. **This requires a field inversion
-    /// and so it is recommended to perform these in a batch
-    /// using [`batch_normalize`](crate::batch_normalize) instead.**
-    fn from(extended: &'a JubJubExtended) -> JubJubAffine {
-        // Z coordinate is always nonzero, so this is
-        // its inverse.
-        let zinv = extended.z.invert().unwrap();
-
-        JubJubAffine {
-            x: extended.x * &zinv,
-            y: extended.y * &zinv,
+impl From<AffinePoint> for ExtendedPoint {
+    /// Constructs an extended point (with `Z = 1`) from
+    /// an affine point using the map `(u, v) => (u, v, 1, u, v)`.
+    fn from(affine: AffinePoint) -> ExtendedPoint {
+        ExtendedPoint {
+            u: affine.u,
+            v: affine.v,
+            z: Fq::one(),
+            t1: affine.u,
+            t2: affine.v,
         }
     }
 }
 
-impl From<JubJubExtended> for JubJubAffine {
-    fn from(extended: JubJubExtended) -> JubJubAffine {
-        JubJubAffine::from(&extended)
+impl<'a> From<&'a ExtendedPoint> for AffinePoint {
+    /// Constructs an affine point from an extended point
+    /// using the map `(U, V, Z, T1, T2) => (U/Z, V/Z)`
+    /// as Z is always nonzero. **This requires a field inversion
+    /// and so it is recommended to perform these in a batch
+    /// using [`batch_normalize`](crate::batch_normalize) instead.**
+    fn from(extended: &'a ExtendedPoint) -> AffinePoint {
+        // Z coordinate is always nonzero, so this is
+        // its inverse.
+        let zinv = extended.z.invert().unwrap();
+
+        AffinePoint {
+            u: extended.u * zinv,
+            v: extended.v * zinv,
+        }
     }
 }
 
-/// This is a pre-processed version of an affine point `(x, y)`
-/// in the form `(y + x, y - x, x * y * 2d)`. This can be added to an
-/// [`JubJubExtended`](crate::JubJubExtended).
+impl From<ExtendedPoint> for AffinePoint {
+    fn from(extended: ExtendedPoint) -> AffinePoint {
+        AffinePoint::from(&extended)
+    }
+}
+
+/// This is a pre-processed version of an affine point `(u, v)`
+/// in the form `(v + u, v - u, u * v * 2d)`. This can be added to an
+/// [`ExtendedPoint`](crate::ExtendedPoint).
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "rkyv-impl", derive(Archive, Serialize, Deserialize))]
-#[cfg_attr(feature = "rkyv-impl", archive_attr(derive(CheckBytes)))]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct AffineNielsPoint {
-    y_plus_x: BlsScalar,
-    y_minus_x: BlsScalar,
-    t2d: BlsScalar,
+    v_plus_u: Fq,
+    v_minus_u: Fq,
+    t2d: Fq,
 }
 
 impl AffineNielsPoint {
     /// Constructs this point from the neutral element `(0, 1)`.
     pub const fn identity() -> Self {
         AffineNielsPoint {
-            y_plus_x: BlsScalar::one(),
-            y_minus_x: BlsScalar::one(),
-            t2d: BlsScalar::zero(),
+            v_plus_u: Fq::one(),
+            v_minus_u: Fq::one(),
+            t2d: Fq::zero(),
         }
     }
 
     #[inline]
-    fn multiply(&self, by: &[u8; 32]) -> JubJubExtended {
+    fn multiply(&self, by: &[u8; 32]) -> ExtendedPoint {
         let zero = AffineNielsPoint::identity();
 
-        let mut acc = JubJubExtended::identity();
+        let mut acc = ExtendedPoint::identity();
 
         // This is a simple double-and-add implementation of point
         // multiplication, moving from most significant to least
@@ -317,15 +301,14 @@ impl AffineNielsPoint {
         // We skip the leading four bits because they're always
         // unset for Fr.
         for bit in by
+            .as_bits::<Lsb0>()
             .iter()
             .rev()
-            .flat_map(|byte| {
-                (0..8).rev().map(move |i| Choice::from((byte >> i) & 1u8))
-            })
             .skip(4)
+            .map(|bit| Choice::from(if *bit { 1 } else { 0 }))
         {
             acc = acc.double();
-            acc += AffineNielsPoint::conditional_select(&zero, &self, bit);
+            acc += AffineNielsPoint::conditional_select(&zero, self, bit);
         }
 
         acc
@@ -333,66 +316,61 @@ impl AffineNielsPoint {
 
     /// Multiplies this point by the specific little-endian bit pattern in the
     /// given byte array, ignoring the highest four bits.
-    pub fn multiply_bits(&self, by: &[u8; 32]) -> JubJubExtended {
+    pub fn multiply_bits(&self, by: &[u8; 32]) -> ExtendedPoint {
         self.multiply(by)
     }
 }
 
 impl<'a, 'b> Mul<&'b Fr> for &'a AffineNielsPoint {
-    type Output = JubJubExtended;
+    type Output = ExtendedPoint;
 
-    fn mul(self, other: &'b Fr) -> JubJubExtended {
+    fn mul(self, other: &'b Fr) -> ExtendedPoint {
         self.multiply(&other.to_bytes())
     }
 }
 
-impl_binops_multiplicative_mixed!(AffineNielsPoint, Fr, JubJubExtended);
+impl_binops_multiplicative_mixed!(AffineNielsPoint, Fr, ExtendedPoint);
 
 impl ConditionallySelectable for AffineNielsPoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         AffineNielsPoint {
-            y_plus_x: BlsScalar::conditional_select(
-                &a.y_plus_x,
-                &b.y_plus_x,
+            v_plus_u: Fq::conditional_select(&a.v_plus_u, &b.v_plus_u, choice),
+            v_minus_u: Fq::conditional_select(
+                &a.v_minus_u,
+                &b.v_minus_u,
                 choice,
             ),
-            y_minus_x: BlsScalar::conditional_select(
-                &a.y_minus_x,
-                &b.y_minus_x,
-                choice,
-            ),
-            t2d: BlsScalar::conditional_select(&a.t2d, &b.t2d, choice),
+            t2d: Fq::conditional_select(&a.t2d, &b.t2d, choice),
         }
     }
 }
 
-/// This is a pre-processed version of an extended point `(X, Y, Z, T1, T2)`
-/// in the form `(Y + X, Y - X, Z, T1 * T2 * 2d)`.
+/// This is a pre-processed version of an extended point `(U, V, Z, T1, T2)`
+/// in the form `(V + U, V - U, Z, T1 * T2 * 2d)`.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "rkyv-impl", derive(Archive, Serialize, Deserialize))]
-#[cfg_attr(feature = "rkyv-impl", archive_attr(derive(CheckBytes)))]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct ExtendedNielsPoint {
-    y_plus_x: BlsScalar,
-    y_minus_x: BlsScalar,
-    z: BlsScalar,
-    t2d: BlsScalar,
+    v_plus_u: Fq,
+    v_minus_u: Fq,
+    z: Fq,
+    t2d: Fq,
 }
 
 impl ConditionallySelectable for ExtendedNielsPoint {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         ExtendedNielsPoint {
-            y_plus_x: BlsScalar::conditional_select(
-                &a.y_plus_x,
-                &b.y_plus_x,
+            v_plus_u: Fq::conditional_select(&a.v_plus_u, &b.v_plus_u, choice),
+            v_minus_u: Fq::conditional_select(
+                &a.v_minus_u,
+                &b.v_minus_u,
                 choice,
             ),
-            y_minus_x: BlsScalar::conditional_select(
-                &a.y_minus_x,
-                &b.y_minus_x,
-                choice,
-            ),
-            z: BlsScalar::conditional_select(&a.z, &b.z, choice),
-            t2d: BlsScalar::conditional_select(&a.t2d, &b.t2d, choice),
+            z: Fq::conditional_select(&a.z, &b.z, choice),
+            t2d: Fq::conditional_select(&a.t2d, &b.t2d, choice),
         }
     }
 }
@@ -401,18 +379,18 @@ impl ExtendedNielsPoint {
     /// Constructs this point from the neutral element `(0, 1)`.
     pub const fn identity() -> Self {
         ExtendedNielsPoint {
-            y_plus_x: BlsScalar::one(),
-            y_minus_x: BlsScalar::one(),
-            z: BlsScalar::one(),
-            t2d: BlsScalar::zero(),
+            v_plus_u: Fq::one(),
+            v_minus_u: Fq::one(),
+            z: Fq::one(),
+            t2d: Fq::zero(),
         }
     }
 
     #[inline]
-    fn multiply(&self, by: &[u8; 32]) -> JubJubExtended {
+    fn multiply(&self, by: &[u8; 32]) -> ExtendedPoint {
         let zero = ExtendedNielsPoint::identity();
 
-        let mut acc = JubJubExtended::identity();
+        let mut acc = ExtendedPoint::identity();
 
         // This is a simple double-and-add implementation of point
         // multiplication, moving from most significant to least
@@ -429,7 +407,7 @@ impl ExtendedNielsPoint {
             .skip(4)
         {
             acc = acc.double();
-            acc += ExtendedNielsPoint::conditional_select(&zero, &self, bit);
+            acc += ExtendedNielsPoint::conditional_select(&zero, self, bit);
         }
 
         acc
@@ -437,131 +415,66 @@ impl ExtendedNielsPoint {
 
     /// Multiplies this point by the specific little-endian bit pattern in the
     /// given byte array, ignoring the highest four bits.
-    pub fn multiply_bits(&self, by: &[u8; 32]) -> JubJubExtended {
+    pub fn multiply_bits(&self, by: &[u8; 32]) -> ExtendedPoint {
         self.multiply(by)
     }
 }
 
 impl<'a, 'b> Mul<&'b Fr> for &'a ExtendedNielsPoint {
-    type Output = JubJubExtended;
+    type Output = ExtendedPoint;
 
-    fn mul(self, other: &'b Fr) -> JubJubExtended {
+    fn mul(self, other: &'b Fr) -> ExtendedPoint {
         self.multiply(&other.to_bytes())
     }
 }
 
-impl_binops_multiplicative_mixed!(ExtendedNielsPoint, Fr, JubJubExtended);
+impl_binops_multiplicative_mixed!(ExtendedNielsPoint, Fr, ExtendedPoint);
 
-/// `d = -(10240/10241)`
-pub const EDWARDS_D: BlsScalar = BlsScalar::from_raw([
-    0x01065fd6d6343eb1,
-    0x292d7f6d37579d26,
-    0xf5fd9207e6bd7fd4,
-    0x2a9318e74bfa2b48,
+// `d = -(10240/10241)`
+const EDWARDS_D: Fq = Fq::from_raw([
+    0x0106_5fd6_d634_3eb1,
+    0x292d_7f6d_3757_9d26,
+    0xf5fd_9207_e6bd_7fd4,
+    0x2a93_18e7_4bfa_2b48,
 ]);
 
-/// `2*EDWARDS_D`
-pub const EDWARDS_D2: BlsScalar = BlsScalar::from_raw([
-    0x020cbfadac687d62,
-    0x525afeda6eaf3a4c,
-    0xebfb240fcd7affa8,
-    0x552631ce97f45691,
+// `2*d`
+const EDWARDS_D2: Fq = Fq::from_raw([
+    0x020c_bfad_ac68_7d62,
+    0x525a_feda_6eaf_3a4c,
+    0xebfb_240f_cd7a_ffa8,
+    0x5526_31ce_97f4_5691,
 ]);
 
-impl Serializable<32> for JubJubAffine {
-    type Error = BytesError;
-
-    /// Converts this element into its byte representation.
-    fn to_bytes(&self) -> [u8; Self::SIZE] {
-        let mut tmp = self.y.to_bytes();
-        let x = self.x.to_bytes();
-
-        // Encode the sign of the x-coordinate in the most
-        // significant bit.
-        tmp[31] |= x[0] << 7;
-
-        tmp
-    }
-
-    /// Attempts to interpret a byte representation of an
-    /// affine point, failing if the element is not on
-    /// the curve or non-canonical.
-    ///
-    /// NOTE: ZIP 216 is enabled by default and the only way to interact with
-    /// serialization.
-    /// See: <https://zips.z.cash/zip-0216> for more details.
-    fn from_bytes(b: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
-        let mut b = b.clone();
-
-        // Grab the sign bit from the representation
-        let sign = b[31] >> 7;
-
-        // Mask away the sign bit
-        b[31] &= 0b0111_1111;
-
-        // Interpret what remains as the y-coordinate
-        let y = BlsScalar::from_bytes(&b)?;
-
-        // -x^2 + y^2 = 1 + d.x^2.y^2
-        // -x^2 = 1 + d.x^2.y^2 - y^2    (rearrange)
-        // -x^2 - d.x^2.y^2 = 1 - y^2    (rearrange)
-        // x^2 + d.x^2.y^2 = y^2 - 1     (flip signs)
-        // x^2 (1 + d.y^2) = y^2 - 1     (factor)
-        // x^2 = (y^2 - 1) / (1 + d.y^2) (isolate x^2)
-        // We know that (1 + d.y^2) is nonzero for all y:
-        //   (1 + d.y^2) = 0
-        //   d.y^2 = -1
-        //   y^2 = -(1 / d)   No solutions, as -(1 / d) is not a square
-
-        let y2 = y.square();
-
-        Option::from(
-            ((y2 - BlsScalar::one())
-                * ((BlsScalar::one() + EDWARDS_D * &y2)
-                    .invert()
-                    .unwrap_or(BlsScalar::zero())))
-            .sqrt()
-            .and_then(|x| {
-                // Fix the sign of `x` if necessary
-                let flip_sign = Choice::from((x.to_bytes()[0] ^ sign) & 1);
-                let x = BlsScalar::conditional_select(&x, &-x, flip_sign);
-                // If x == 0, flip_sign == sign_bit. We therefore want to reject
-                // the encoding as non-canonical if all of the
-                // following occur:
-                // - x == 0
-                // - flip_sign == true
-                let x_is_zero = x.ct_eq(&BlsScalar::zero());
-                CtOption::new(JubJubAffine { x, y }, !(x_is_zero & flip_sign))
-            }),
-        )
-        .ok_or(BytesError::InvalidData)
-    }
-}
-
-impl JubJubAffine {
+impl AffinePoint {
     /// Constructs the neutral element `(0, 1)`.
     pub const fn identity() -> Self {
-        JubJubAffine {
-            x: BlsScalar::zero(),
-            y: BlsScalar::one(),
+        AffinePoint {
+            u: Fq::zero(),
+            v: Fq::one(),
         }
     }
 
+    /// Determines if this point is the identity.
+    pub fn is_identity(&self) -> Choice {
+        ExtendedPoint::from(*self).is_identity()
+    }
+
     /// Multiplies this point by the cofactor, producing an
-    /// `JubJubExtended`
-    pub fn mul_by_cofactor(&self) -> JubJubExtended {
-        JubJubExtended::from(*self).mul_by_cofactor()
+    /// `ExtendedPoint`
+    pub fn mul_by_cofactor(&self) -> ExtendedPoint {
+        ExtendedPoint::from(*self).mul_by_cofactor()
     }
 
     /// Determines if this point is of small order.
     pub fn is_small_order(&self) -> Choice {
-        JubJubExtended::from(*self).is_small_order()
+        ExtendedPoint::from(*self).is_small_order()
     }
 
     /// Determines if this point is torsion free and so is
     /// in the prime order subgroup.
     pub fn is_torsion_free(&self) -> Choice {
-        JubJubExtended::from(*self).is_torsion_free()
+        ExtendedPoint::from(*self).is_torsion_free()
     }
 
     /// Determines if this point is prime order, or in other words that
@@ -569,37 +482,245 @@ impl JubJubAffine {
     /// identity is `r`. This is equivalent to checking that the point
     /// is both torsion free and not the identity.
     pub fn is_prime_order(&self) -> Choice {
-        let extended = JubJubExtended::from(*self);
+        let extended = ExtendedPoint::from(*self);
         extended.is_torsion_free() & (!extended.is_identity())
     }
 
-    /// Returns the `x`-coordinate of this point.
-    pub const fn get_x(&self) -> BlsScalar {
-        self.x
+    /// Converts this element into its byte representation.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut tmp = self.v.to_bytes();
+        let u = self.u.to_bytes();
+
+        // Encode the sign of the u-coordinate in the most
+        // significant bit.
+        tmp[31] |= u[0] << 7;
+
+        tmp
     }
 
-    /// Returns the `y`-coordinate of this point.
-    pub const fn get_y(&self) -> BlsScalar {
-        self.y
+    /// Attempts to interpret a byte representation of an
+    /// affine point, failing if the element is not on
+    /// the curve or non-canonical.
+    pub fn from_bytes(b: [u8; 32]) -> CtOption<Self> {
+        Self::from_bytes_inner(b, 1.into())
+    }
+
+    /// Attempts to interpret a byte representation of an affine point, failing
+    /// if the element is not on the curve.
+    ///
+    /// Most non-canonical encodings will also cause a failure. However, this
+    /// API preserves (for use in consensus-critical protocols) a bug in the
+    /// parsing code that caused two non-canonical encodings to be
+    /// **silently** accepted:
+    ///
+    /// - (0, 1), which is the identity;
+    /// - (0, -1), which is a point of order two.
+    ///
+    /// Each of these has a single non-canonical encoding in which the value of
+    /// the sign bit is 1.
+    ///
+    /// See [ZIP 216](https://zips.z.cash/zip-0216) for a more detailed description of the
+    /// bug, as well as its fix.
+    pub fn from_bytes_pre_zip216_compatibility(b: [u8; 32]) -> CtOption<Self> {
+        Self::from_bytes_inner(b, 0.into())
+    }
+
+    fn from_bytes_inner(
+        mut b: [u8; 32],
+        zip_216_enabled: Choice,
+    ) -> CtOption<Self> {
+        // Grab the sign bit from the representation
+        let sign = b[31] >> 7;
+
+        // Mask away the sign bit
+        b[31] &= 0b0111_1111;
+
+        // Interpret what remains as the v-coordinate
+        Fq::from_bytes(&b).and_then(|v| {
+            // -u^2 + v^2 = 1 + d.u^2.v^2
+            // -u^2 = 1 + d.u^2.v^2 - v^2    (rearrange)
+            // -u^2 - d.u^2.v^2 = 1 - v^2    (rearrange)
+            // u^2 + d.u^2.v^2 = v^2 - 1     (flip signs)
+            // u^2 (1 + d.v^2) = v^2 - 1     (factor)
+            // u^2 = (v^2 - 1) / (1 + d.v^2) (isolate u^2)
+            // We know that (1 + d.v^2) is nonzero for all v:
+            //   (1 + d.v^2) = 0
+            //   d.v^2 = -1
+            //   v^2 = -(1 / d)   No solutions, as -(1 / d) is not a square
+
+            let v2 = v.square();
+
+            ((v2 - Fq::one())
+                * ((Fq::one() + EDWARDS_D * v2).invert().unwrap_or(Fq::zero())))
+            .sqrt()
+            .and_then(|u| {
+                // Fix the sign of `u` if necessary
+                let flip_sign = Choice::from((u.to_bytes()[0] ^ sign) & 1);
+                let u_negated = -u;
+                let final_u = Fq::conditional_select(&u, &u_negated, flip_sign);
+
+                // If u == 0, flip_sign == sign_bit. We therefore want to reject
+                // the encoding as non-canonical if all of the
+                // following occur:
+                // - ZIP 216 is enabled
+                // - u == 0
+                // - flip_sign == true
+                let u_is_zero = u.ct_eq(&Fq::zero());
+                CtOption::new(
+                    AffinePoint { u: final_u, v },
+                    !(zip_216_enabled & u_is_zero & flip_sign),
+                )
+            })
+        })
+    }
+
+    /// Attempts to interpret a batch of byte representations of affine points.
+    ///
+    /// Returns None for each element if it is not on the curve, or is
+    /// non-canonical according to ZIP 216.
+    #[cfg(feature = "alloc")]
+    pub fn batch_from_bytes(
+        items: impl Iterator<Item = [u8; 32]>,
+    ) -> Vec<CtOption<Self>> {
+        use ff::BatchInvert;
+
+        #[derive(Clone, Copy, Default)]
+        struct Item {
+            sign: u8,
+            v: Fq,
+            numerator: Fq,
+            denominator: Fq,
+        }
+
+        impl ConditionallySelectable for Item {
+            fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+                Item {
+                    sign: u8::conditional_select(&a.sign, &b.sign, choice),
+                    v: Fq::conditional_select(&a.v, &b.v, choice),
+                    numerator: Fq::conditional_select(
+                        &a.numerator,
+                        &b.numerator,
+                        choice,
+                    ),
+                    denominator: Fq::conditional_select(
+                        &a.denominator,
+                        &b.denominator,
+                        choice,
+                    ),
+                }
+            }
+        }
+
+        let items: Vec<_> = items
+            .map(|mut b| {
+                // Grab the sign bit from the representation
+                let sign = b[31] >> 7;
+
+                // Mask away the sign bit
+                b[31] &= 0b0111_1111;
+
+                // Interpret what remains as the v-coordinate
+                Fq::from_bytes(&b).map(|v| {
+                    // -u^2 + v^2 = 1 + d.u^2.v^2
+                    // -u^2 = 1 + d.u^2.v^2 - v^2    (rearrange)
+                    // -u^2 - d.u^2.v^2 = 1 - v^2    (rearrange)
+                    // u^2 + d.u^2.v^2 = v^2 - 1     (flip signs)
+                    // u^2 (1 + d.v^2) = v^2 - 1     (factor)
+                    // u^2 = (v^2 - 1) / (1 + d.v^2) (isolate u^2)
+                    // We know that (1 + d.v^2) is nonzero for all v:
+                    //   (1 + d.v^2) = 0
+                    //   d.v^2 = -1
+                    //   v^2 = -(1 / d)   No solutions, as -(1 / d) is not a
+                    // square
+
+                    let v2 = v.square();
+
+                    Item {
+                        v,
+                        sign,
+                        numerator: (v2 - Fq::one()),
+                        denominator: Fq::one() + EDWARDS_D * v2,
+                    }
+                })
+            })
+            .collect();
+
+        let mut denominators: Vec<_> = items
+            .iter()
+            .map(|item| item.map(|item| item.denominator).unwrap_or(Fq::zero()))
+            .collect();
+        denominators.iter_mut().batch_invert();
+
+        items
+            .into_iter()
+            .zip(denominators.into_iter())
+            .map(|(item, inv_denominator)| {
+                item.and_then(
+                    |Item {
+                         v, sign, numerator, ..
+                     }| {
+                        (numerator * inv_denominator).sqrt().and_then(|u| {
+                            // Fix the sign of `u` if necessary
+                            let flip_sign =
+                                Choice::from((u.to_bytes()[0] ^ sign) & 1);
+                            let u_negated = -u;
+                            let final_u = Fq::conditional_select(
+                                &u, &u_negated, flip_sign,
+                            );
+
+                            // If u == 0, flip_sign == sign_bit. We therefore
+                            // want to reject the
+                            // encoding as non-canonical if all of the following
+                            // occur:
+                            // - u == 0
+                            // - flip_sign == true
+                            let u_is_zero = u.ct_eq(&Fq::zero());
+                            CtOption::new(
+                                AffinePoint { u: final_u, v },
+                                !(u_is_zero & flip_sign),
+                            )
+                        })
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Returns the `u`-coordinate of this point.
+    pub fn get_u(&self) -> Fq {
+        self.u
+    }
+
+    /// Returns the `v`-coordinate of this point.
+    pub fn get_v(&self) -> Fq {
+        self.v
+    }
+
+    /// Returns an `ExtendedPoint` for use in arithmetic operations.
+    pub const fn to_extended(&self) -> ExtendedPoint {
+        ExtendedPoint {
+            u: self.u,
+            v: self.v,
+            z: Fq::one(),
+            t1: self.u,
+            t2: self.v,
+        }
     }
 
     /// Performs a pre-processing step that produces an `AffineNielsPoint`
     /// for use in multiple additions.
     pub const fn to_niels(&self) -> AffineNielsPoint {
         AffineNielsPoint {
-            y_plus_x: BlsScalar::add(&self.y, &self.x),
-            y_minus_x: BlsScalar::sub(&self.y, &self.x),
-            t2d: BlsScalar::mul(&BlsScalar::mul(&self.x, &self.y), &EDWARDS_D2),
+            v_plus_u: Fq::add(&self.v, &self.u),
+            v_minus_u: Fq::sub(&self.v, &self.u),
+            t2d: Fq::mul(&Fq::mul(&self.u, &self.v), &EDWARDS_D2),
         }
     }
 
-    /// Constructs an JubJubAffine given `x` and `y` without checking
+    /// Constructs an AffinePoint given `u` and `v` without checking
     /// that the point is on the curve.
-    pub const fn from_raw_unchecked(
-        x: BlsScalar,
-        y: BlsScalar,
-    ) -> JubJubAffine {
-        JubJubAffine { x, y }
+    pub const fn from_raw_unchecked(u: Fq, v: Fq) -> AffinePoint {
+        AffinePoint { u, v }
     }
 
     /// This is only for debugging purposes and not
@@ -607,88 +728,40 @@ impl JubJubAffine {
     /// point is on the curve.
     #[cfg(test)]
     fn is_on_curve_vartime(&self) -> bool {
-        let x2 = self.x.square();
-        let y2 = self.y.square();
+        let u2 = self.u.square();
+        let v2 = self.v.square();
 
-        &y2 - &x2 == BlsScalar::one() + &EDWARDS_D * &x2 * &y2
+        v2 - u2 == Fq::one() + EDWARDS_D * u2 * v2
     }
 }
 
-impl JubJubExtended {
-    /// Constructs an extended point (with `Z = 1`) from
-    /// an affine point using the map `(x, y) => (x, y, 1, x, y)`.
-    pub const fn from_affine(affine: JubJubAffine) -> Self {
-        Self::from_raw_unchecked(
-            affine.x,
-            affine.y,
-            BlsScalar::one(),
-            affine.x,
-            affine.y,
-        )
-    }
-
-    /// Constructs an extended point from its raw internals
-    pub const fn from_raw_unchecked(
-        x: BlsScalar,
-        y: BlsScalar,
-        z: BlsScalar,
-        t1: BlsScalar,
-        t2: BlsScalar,
-    ) -> Self {
-        JubJubExtended { x, y, z, t1, t2 }
-    }
-
-    /// Returns the `x`-coordinate of this point.
-    pub const fn get_x(&self) -> BlsScalar {
-        self.x
-    }
-
-    /// Returns the `y`-coordinate of this point.
-    pub const fn get_y(&self) -> BlsScalar {
-        self.y
-    }
-
-    /// Returns the `z`-coordinate of this point.
-    pub const fn get_z(&self) -> BlsScalar {
-        self.z
-    }
-
-    /// Returns the `t1`-coordinate of this point.
-    pub const fn get_t1(&self) -> BlsScalar {
-        self.t1
-    }
-
-    /// Returns the `t2`-coordinate of this point.
-    pub const fn get_t2(&self) -> BlsScalar {
-        self.t2
-    }
-
+impl ExtendedPoint {
     /// Constructs an extended point from the neutral element `(0, 1)`.
     pub const fn identity() -> Self {
-        JubJubExtended {
-            x: BlsScalar::zero(),
-            y: BlsScalar::one(),
-            z: BlsScalar::one(),
-            t1: BlsScalar::zero(),
-            t2: BlsScalar::zero(),
+        ExtendedPoint {
+            u: Fq::zero(),
+            v: Fq::one(),
+            z: Fq::one(),
+            t1: Fq::zero(),
+            t2: Fq::zero(),
         }
     }
 
     /// Determines if this point is the identity.
     pub fn is_identity(&self) -> Choice {
         // If this point is the identity, then
-        //     x = 0 * z = 0
-        // and y = 1 * z = z
-        self.x.ct_eq(&BlsScalar::zero()) & self.y.ct_eq(&self.z)
+        //     u = 0 * z = 0
+        // and v = 1 * z = z
+        self.u.ct_eq(&Fq::zero()) & self.v.ct_eq(&self.z)
     }
 
     /// Determines if this point is of small order.
     pub fn is_small_order(&self) -> Choice {
         // We only need to perform two doublings, since the 2-torsion
         // points are (0, 1) and (0, -1), and so we only need to check
-        // that the x-coordinate of the result is zero to see if the
+        // that the u-coordinate of the result is zero to see if the
         // point is small order.
-        self.double().double().x.ct_eq(&BlsScalar::zero())
+        self.double().double().u.ct_eq(&Fq::zero())
     }
 
     /// Determines if this point is torsion free and so is contained
@@ -706,7 +779,7 @@ impl JubJubExtended {
     }
 
     /// Multiplies this element by the cofactor `8`.
-    pub fn mul_by_cofactor(&self) -> JubJubExtended {
+    pub fn mul_by_cofactor(&self) -> ExtendedPoint {
         self.double().double().double()
     }
 
@@ -714,26 +787,16 @@ impl JubJubExtended {
     /// for use in multiple additions.
     pub fn to_niels(&self) -> ExtendedNielsPoint {
         ExtendedNielsPoint {
-            y_plus_x: &self.y + &self.x,
-            y_minus_x: &self.y - &self.x,
+            v_plus_u: self.v + self.u,
+            v_minus_u: self.v - self.u,
             z: self.z,
-            t2d: &self.t1 * &self.t2 * EDWARDS_D2,
+            t2d: self.t1 * self.t2 * EDWARDS_D2,
         }
-    }
-
-    /// Returns two scalars suitable for hashing that represent the
-    /// Extended Point.
-    pub fn to_hash_inputs(&self) -> [BlsScalar; 2] {
-        // The same JubJubAffine can have different JubJubExtended
-        // representations, therefore we convert from Extended to Affine
-        // before hashing, to ensure deterministic result
-        let p = JubJubAffine::from(self);
-        [p.x, p.y]
     }
 
     /// Computes the doubling of a point more efficiently than a point can
     /// be added to itself.
-    pub fn double(&self) -> JubJubExtended {
+    pub fn double(&self) -> ExtendedPoint {
         // Doubling is more efficient (three multiplications, four squarings)
         // when we work within the projective coordinate space (U:Z, V:Z). We
         // rely on the most efficient formula, "dbl-2008-bbjlp", as described
@@ -742,88 +805,84 @@ impl JubJubExtended {
         // See <https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html#doubling-dbl-2008-bbjlp>
         // for more information.
         //
-        // We differ from the literature in that we use (x, y) rather than
+        // We differ from the literature in that we use (u, v) rather than
         // (x, y) coordinates. We also have the constant `a = -1` implied. Let
-        // us rewrite the procedure of doubling (x, y, z) to produce (X, Y, Z)
+        // us rewrite the procedure of doubling (u, v, z) to produce (U, V, Z)
         // as follows:
         //
-        // B = (x + y)^2
-        // C = x^2
-        // D = y^2
+        // B = (u + v)^2
+        // C = u^2
+        // D = v^2
         // F = D - C
         // H = 2 * z^2
         // J = F - H
-        // X = (B - C - D) * J
-        // Y = F * (- C - D)
+        // U = (B - C - D) * J
+        // V = F * (- C - D)
         // Z = F * J
         //
         // If we compute K = D + C, we can rewrite this:
         //
-        // B = (x + y)^2
-        // C = x^2
-        // D = y^2
+        // B = (u + v)^2
+        // C = u^2
+        // D = v^2
         // F = D - C
         // K = D + C
         // H = 2 * z^2
         // J = F - H
-        // X = (B - K) * J
-        // Y = F * (-K)
+        // U = (B - K) * J
+        // V = F * (-K)
         // Z = F * J
         //
         // In order to avoid the unnecessary negation of K,
         // we will negate J, transforming the result into
         // an equivalent point with a negated z-coordinate.
         //
-        // B = (x + y)^2
-        // C = x^2
-        // D = y^2
+        // B = (u + v)^2
+        // C = u^2
+        // D = v^2
         // F = D - C
         // K = D + C
         // H = 2 * z^2
         // J = H - F
-        // X = (B - K) * J
-        // Y = F * K
+        // U = (B - K) * J
+        // V = F * K
         // Z = F * J
         //
         // Let us rename some variables to simplify:
         //
-        // XY2 = (x + y)^2
-        // XX = x^2
-        // YY = y^2
-        // YYmXX = YY - XX
-        // YYpXX = YY + XX
+        // UV2 = (u + v)^2
+        // UU = u^2
+        // VV = v^2
+        // VVmUU = VV - UU
+        // VVpUU = VV + UU
         // ZZ2 = 2 * z^2
-        // J = ZZ2 - YYmXX
-        // X = (XY2 - YYpXX) * J
-        // Y = YYmXX * YYXX
-        // Z = YYmXX * J
+        // J = ZZ2 - VVmUU
+        // U = (UV2 - VVpUU) * J
+        // V = VVmUU * VVpUU
+        // Z = VVmUU * J
         //
-        // We wish to obtain two factors of T = XY / Z.
+        // We wish to obtain two factors of T = UV/Z.
         //
-        // XY / Z
-        // =
-        // (XY2 - YYpXX) * (ZZ2 - VVmUU) * YYmXX * YYpXX / YYmXX / (ZZ2 - YYmXX)
-        // =
-        // (XY2 - YYpXX) * YYmXX * YYpXX / YYmXX
-        // =
-        // (XY2 - YYpXX) * YYpXX
+        // UV/Z = (UV2 - VVpUU) * (ZZ2 - VVmUU) * VVmUU * VVpUU / VVmUU / (ZZ2 -
+        // VVmUU)      = (UV2 - VVpUU) * VVmUU * VVpUU / VVmUU
+        //      = (UV2 - VVpUU) * VVpUU
         //
-        // and so we have that T1 = (XY2 - YYpXX) and T2 = YYpXX.
+        // and so we have that T1 = (UV2 - VVpUU) and T2 = VVpUU.
 
-        let xx = self.x.square();
-        let yy = self.y.square();
+        let uu = self.u.square();
+        let vv = self.v.square();
         let zz2 = self.z.square().double();
-        let xy2 = (&self.x + &self.y).square();
-        let yy_plus_xx = &yy + &xx;
-        let yy_minus_xx = &yy - &xx;
+        let uv2 = (self.u + self.v).square();
+        let vv_plus_uu = vv + uu;
+        let vv_minus_uu = vv - uu;
 
         // The remaining arithmetic is exactly the process of converting
         // from a completed point to an extended point.
         CompletedPoint {
-            x: &xy2 - &yy_plus_xx,
-            y: yy_plus_xx,
-            z: yy_minus_xx,
-            t: &zz2 - &yy_minus_xx,
+            u: uv2 - vv_plus_uu,
+            v: vv_plus_uu,
+            z: vv_minus_uu,
+            t: zz2 - vv_minus_uu,
         }
         .into_extended()
     }
@@ -833,259 +892,275 @@ impl JubJubExtended {
         self.to_niels().multiply(by)
     }
 
+    /// Converts a batch of projective elements into affine elements.
+    ///
+    /// This function will panic if `p.len() != q.len()`.
+    ///
+    /// This costs 5 multiplications per element, and a field inversion.
+    fn batch_normalize(p: &[Self], q: &mut [AffinePoint]) {
+        assert_eq!(p.len(), q.len());
+
+        for (p, q) in p.iter().zip(q.iter_mut()) {
+            // We use the `u` field of `AffinePoint` to store the z-coordinate
+            // being inverted, and the `v` field for scratch space.
+            q.u = p.z;
+        }
+
+        BatchInverter::invert_with_internal_scratch(
+            q,
+            |q| &mut q.u,
+            |q| &mut q.v,
+        );
+
+        for (p, q) in p.iter().zip(q.iter_mut()).rev() {
+            let tmp = q.u;
+
+            // Set the coordinates to the correct value
+            q.u = p.u * tmp; // Multiply by 1/z
+            q.v = p.v * tmp; // Multiply by 1/z
+        }
+    }
+
     /// This is only for debugging purposes and not
     /// exposed in the public API. Checks that this
     /// point is on the curve.
     #[cfg(test)]
     fn is_on_curve_vartime(&self) -> bool {
-        let affine = JubJubAffine::from(*self);
+        let affine = AffinePoint::from(*self);
 
-        self.z != BlsScalar::zero()
+        self.z != Fq::zero()
             && affine.is_on_curve_vartime()
-            && (affine.x * affine.y * self.z == self.t1 * self.t2)
+            && (affine.u * affine.v * self.z == self.t1 * self.t2)
     }
 }
 
-impl<'a, 'b> Mul<&'b Fr> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Mul<&'b Fr> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
-    fn mul(self, other: &'b Fr) -> JubJubExtended {
+    fn mul(self, other: &'b Fr) -> ExtendedPoint {
         self.multiply(&other.to_bytes())
     }
 }
 
-impl_binops_multiplicative!(JubJubExtended, Fr);
+impl_binops_multiplicative!(ExtendedPoint, Fr);
 
-impl<'a, 'b> Add<&'b ExtendedNielsPoint> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Add<&'b ExtendedNielsPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
-    fn add(self, other: &'b ExtendedNielsPoint) -> JubJubExtended {
+    fn add(self, other: &'b ExtendedNielsPoint) -> ExtendedPoint {
         // We perform addition in the extended coordinates. Here we use
         // a formula presented by Hisil, Wong, Carter and Dawson in
         // "Twisted Edward Curves Revisited" which only requires 8M.
         //
-        // A = (Y1 - X1) * (Y2 - X2)
-        // B = (Y1 + X1) * (Y2 + X2)
+        // A = (V1 - U1) * (V2 - U2)
+        // B = (V1 + U1) * (V2 + U2)
         // C = 2d * T1 * T2
         // D = 2 * Z1 * Z2
         // E = B - A
         // F = D - C
         // G = D + C
         // H = B + A
-        // X3 = E * F
+        // U3 = E * F
         // Y3 = G * H
         // Z3 = F * G
         // T3 = E * H
 
-        let a = (&self.y - &self.x) * &other.y_minus_x;
-        let b = (&self.y + &self.x) * &other.y_plus_x;
-        let c = &self.t1 * &self.t2 * &other.t2d;
-        let d = (&self.z * &other.z).double();
+        let a = (self.v - self.u) * other.v_minus_u;
+        let b = (self.v + self.u) * other.v_plus_u;
+        let c = self.t1 * self.t2 * other.t2d;
+        let d = (self.z * other.z).double();
 
         // The remaining arithmetic is exactly the process of converting
         // from a completed point to an extended point.
         CompletedPoint {
-            x: &b - &a,
-            y: &b + &a,
-            z: &d + &c,
-            t: &d - &c,
+            u: b - a,
+            v: b + a,
+            z: d + c,
+            t: d - c,
         }
         .into_extended()
     }
 }
 
-impl<'a, 'b> Sub<&'b ExtendedNielsPoint> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Sub<&'b ExtendedNielsPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
-    fn sub(self, other: &'b ExtendedNielsPoint) -> JubJubExtended {
-        let a = (&self.y - &self.x) * &other.y_plus_x;
-        let b = (&self.y + &self.x) * &other.y_minus_x;
-        let c = &self.t1 * &self.t2 * &other.t2d;
-        let d = (&self.z * &other.z).double();
+    fn sub(self, other: &'b ExtendedNielsPoint) -> ExtendedPoint {
+        let a = (self.v - self.u) * other.v_plus_u;
+        let b = (self.v + self.u) * other.v_minus_u;
+        let c = self.t1 * self.t2 * other.t2d;
+        let d = (self.z * other.z).double();
 
         CompletedPoint {
-            x: &b - &a,
-            y: &b + &a,
-            z: &d - &c,
-            t: &d + &c,
+            u: b - a,
+            v: b + a,
+            z: d - c,
+            t: d + c,
         }
         .into_extended()
     }
 }
 
-impl_binops_additive!(JubJubExtended, ExtendedNielsPoint);
+impl_binops_additive!(ExtendedPoint, ExtendedNielsPoint);
 
-impl<'a, 'b> Add<&'b AffineNielsPoint> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
-    fn add(self, other: &'b AffineNielsPoint) -> JubJubExtended {
+    fn add(self, other: &'b AffineNielsPoint) -> ExtendedPoint {
         // This is identical to the addition formula for `ExtendedNielsPoint`,
         // except we can assume that `other.z` is one, so that we perform
         // 7 multiplications.
 
-        let a = (&self.y - &self.x) * &other.y_minus_x;
-        let b = (&self.y + &self.x) * &other.y_plus_x;
-        let c = &self.t1 * &self.t2 * &other.t2d;
+        let a = (self.v - self.u) * other.v_minus_u;
+        let b = (self.v + self.u) * other.v_plus_u;
+        let c = self.t1 * self.t2 * other.t2d;
         let d = self.z.double();
 
         // The remaining arithmetic is exactly the process of converting
         // from a completed point to an extended point.
         CompletedPoint {
-            x: &b - &a,
-            y: &b + &a,
-            z: &d + &c,
-            t: &d - &c,
+            u: b - a,
+            v: b + a,
+            z: d + c,
+            t: d - c,
         }
         .into_extended()
     }
 }
 
-impl<'a, 'b> Sub<&'b AffineNielsPoint> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
-    fn sub(self, other: &'b AffineNielsPoint) -> JubJubExtended {
-        let a = (&self.y - &self.x) * &other.y_plus_x;
-        let b = (&self.y + &self.x) * &other.y_minus_x;
-        let c = &self.t1 * &self.t2 * &other.t2d;
+    fn sub(self, other: &'b AffineNielsPoint) -> ExtendedPoint {
+        let a = (self.v - self.u) * other.v_plus_u;
+        let b = (self.v + self.u) * other.v_minus_u;
+        let c = self.t1 * self.t2 * other.t2d;
         let d = self.z.double();
 
         CompletedPoint {
-            x: &b - &a,
-            y: &b + &a,
-            z: &d - &c,
-            t: &d + &c,
+            u: b - a,
+            v: b + a,
+            z: d - c,
+            t: d + c,
         }
         .into_extended()
     }
 }
 
-impl_binops_additive!(JubJubExtended, AffineNielsPoint);
+impl_binops_additive!(ExtendedPoint, AffineNielsPoint);
 
-impl<'a, 'b> Add<&'b JubJubExtended> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Add<&'b ExtendedPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[inline]
-    fn add(self, other: &'b JubJubExtended) -> JubJubExtended {
+    fn add(self, other: &'b ExtendedPoint) -> ExtendedPoint {
         self + other.to_niels()
     }
 }
 
-impl<'a, 'b> Sub<&'b JubJubExtended> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[inline]
-    fn sub(self, other: &'b JubJubExtended) -> JubJubExtended {
+    fn sub(self, other: &'b ExtendedPoint) -> ExtendedPoint {
         self - other.to_niels()
     }
 }
 
-impl_binops_additive!(JubJubExtended, JubJubExtended);
+impl_binops_additive!(ExtendedPoint, ExtendedPoint);
 
-impl<'a, 'b> Add<&'b JubJubAffine> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Add<&'b AffinePoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[inline]
-    fn add(self, other: &'b JubJubAffine) -> JubJubExtended {
+    fn add(self, other: &'b AffinePoint) -> ExtendedPoint {
         self + other.to_niels()
     }
 }
 
-impl<'a, 'b> Sub<&'b JubJubAffine> for &'a JubJubExtended {
-    type Output = JubJubExtended;
+impl<'a, 'b> Sub<&'b AffinePoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
 
     #[inline]
-    fn sub(self, other: &'b JubJubAffine) -> JubJubExtended {
+    fn sub(self, other: &'b AffinePoint) -> ExtendedPoint {
         self - other.to_niels()
     }
 }
 
-impl_binops_additive!(JubJubExtended, JubJubAffine);
+impl_binops_additive!(ExtendedPoint, AffinePoint);
 
 /// This is a "completed" point produced during a point doubling or
-/// addition routine. These points exist in the `(X:Z, Y:T)` model
+/// addition routine. These points exist in the `(U:Z, V:T)` model
 /// of the curve. This is not exposed in the API because it is
 /// an implementation detail.
 struct CompletedPoint {
-    x: BlsScalar,
-    y: BlsScalar,
-    z: BlsScalar,
-    t: BlsScalar,
+    u: Fq,
+    v: Fq,
+    z: Fq,
+    t: Fq,
 }
 
 impl CompletedPoint {
     /// This converts a completed point into an extended point by
     /// homogenizing:
     ///
-    /// (x/z, y/t) = (x/z * t/t, y/t * z/z) = (xt/zt, yz/zt)
+    /// (u/z, v/t) = (u/z * t/t, v/t * z/z) = (ut/zt, vz/zt)
     ///
-    /// The resulting T coordinate is xtyz/zt = xy, and so
-    /// T1 = x, T2 = y, without loss of generality.
+    /// The resulting T coordinate is utvz/zt = uv, and so
+    /// T1 = u, T2 = v, without loss of generality.
     #[inline]
-    fn into_extended(self) -> JubJubExtended {
-        JubJubExtended {
-            x: &self.x * &self.t,
-            y: &self.y * &self.z,
-            z: &self.z * &self.t,
-            t1: self.x,
-            t2: self.y,
+    fn into_extended(self) -> ExtendedPoint {
+        ExtendedPoint {
+            u: self.u * self.t,
+            v: self.v * self.z,
+            z: self.z * self.t,
+            t1: self.u,
+            t2: self.v,
         }
     }
 }
 
-impl Default for JubJubAffine {
+impl Default for AffinePoint {
     /// Returns the identity.
-    fn default() -> JubJubAffine {
-        JubJubAffine::identity()
+    fn default() -> AffinePoint {
+        AffinePoint::identity()
     }
 }
 
-impl Default for JubJubExtended {
+impl Default for ExtendedPoint {
     /// Returns the identity.
-    fn default() -> JubJubExtended {
-        JubJubExtended::identity()
+    fn default() -> ExtendedPoint {
+        ExtendedPoint::identity()
     }
 }
 
-/// This takes a mutable slice of `JubJubExtended`s and "normalizes" them using
+/// This takes a mutable slice of `ExtendedPoint`s and "normalizes" them using
 /// only a single inversion for the entire batch. This normalization results in
 /// all of the points having a Z-coordinate of one. Further, an iterator is
-/// returned which can be used to obtain `JubJubAffine`s for each element in the
+/// returned which can be used to obtain `AffinePoint`s for each element in the
 /// slice.
 ///
 /// This costs 5 multiplications per element, and a field inversion.
-pub fn batch_normalize<'a>(
-    y: &'a mut [JubJubExtended],
-) -> impl Iterator<Item = JubJubAffine> + 'a {
-    let mut acc = BlsScalar::one();
-    for p in y.iter_mut() {
-        // We use the `t1` field of `JubJubExtended` to store the product
-        // of previous z-coordinates seen.
-        p.t1 = acc;
-        acc *= &p.z;
-    }
+pub fn batch_normalize(
+    v: &mut [ExtendedPoint],
+) -> impl Iterator<Item = AffinePoint> + '_ {
+    // We use the `t1` field of `ExtendedPoint` for scratch space.
+    BatchInverter::invert_with_internal_scratch(v, |p| &mut p.z, |p| &mut p.t1);
 
-    // This is the inverse, as all z-coordinates are nonzero.
-    acc = acc.invert().unwrap();
-
-    for p in y.iter_mut().rev() {
+    for p in v.iter_mut() {
         let mut q = *p;
-
-        // Compute tmp = 1/z
-        let tmp = q.t1 * acc;
-
-        // Cancel out z-coordinate in denominator of `acc`
-        acc *= &q.z;
+        let tmp = q.z;
 
         // Set the coordinates to the correct value
-        q.x *= &tmp; // Multiply by 1/z
-        q.y *= &tmp; // Multiply by 1/z
-        q.z = BlsScalar::one(); // z-coordinate is now one
-        q.t1 = q.x;
-        q.t2 = q.y;
+        q.u *= &tmp; // Multiply by 1/z
+        q.v *= &tmp; // Multiply by 1/z
+        q.z = Fq::one(); // z-coordinate is now one
+        q.t1 = q.u;
+        q.t2 = q.v;
 
         *p = q;
     }
@@ -1094,110 +1169,427 @@ pub fn batch_normalize<'a>(
     // doesn't encode this fact. Let us offer affine points
     // to the caller.
 
-    y.iter().map(|p| JubJubAffine { x: p.x, y: p.y })
+    v.iter().map(|p| AffinePoint { u: p.u, v: p.v })
+}
+
+impl<'a, 'b> Mul<&'b Fr> for &'a AffinePoint {
+    type Output = ExtendedPoint;
+
+    fn mul(self, other: &'b Fr) -> ExtendedPoint {
+        self.to_niels().multiply(&other.to_bytes())
+    }
+}
+
+impl_binops_multiplicative_mixed!(AffinePoint, Fr, ExtendedPoint);
+
+/// This represents a point in the prime-order subgroup of Jubjub, in extended
+/// coordinates.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct SubgroupPoint(ExtendedPoint);
+
+impl From<SubgroupPoint> for ExtendedPoint {
+    fn from(val: SubgroupPoint) -> ExtendedPoint {
+        val.0
+    }
+}
+
+impl<'a> From<&'a SubgroupPoint> for &'a ExtendedPoint {
+    fn from(val: &'a SubgroupPoint) -> &'a ExtendedPoint {
+        &val.0
+    }
+}
+
+impl fmt::Display for SubgroupPoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl ConditionallySelectable for SubgroupPoint {
+    fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
+        SubgroupPoint(ExtendedPoint::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+impl SubgroupPoint {
+    /// Constructs an AffinePoint given `u` and `v` without checking that the
+    /// point is on the curve or in the prime-order subgroup.
+    ///
+    /// This should only be used for hard-coding constants (e.g. fixed
+    /// generators); in all other cases, use [`SubgroupPoint::from_bytes`]
+    /// instead.
+    ///
+    /// [`SubgroupPoint::from_bytes`]: SubgroupPoint#impl-GroupEncoding
+    pub const fn from_raw_unchecked(u: Fq, v: Fq) -> Self {
+        SubgroupPoint(AffinePoint::from_raw_unchecked(u, v).to_extended())
+    }
+}
+
+impl<T> Sum<T> for SubgroupPoint
+where
+    T: Borrow<SubgroupPoint>,
+{
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T>,
+    {
+        iter.fold(Self::identity(), |acc, item| acc + item.borrow())
+    }
+}
+
+impl Neg for SubgroupPoint {
+    type Output = SubgroupPoint;
+
+    #[inline]
+    fn neg(self) -> SubgroupPoint {
+        SubgroupPoint(-self.0)
+    }
+}
+
+impl Neg for &SubgroupPoint {
+    type Output = SubgroupPoint;
+
+    #[inline]
+    fn neg(self) -> SubgroupPoint {
+        SubgroupPoint(-self.0)
+    }
+}
+
+impl<'a, 'b> Add<&'b SubgroupPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
+
+    #[inline]
+    fn add(self, other: &'b SubgroupPoint) -> ExtendedPoint {
+        self + other.0
+    }
+}
+
+impl<'a, 'b> Sub<&'b SubgroupPoint> for &'a ExtendedPoint {
+    type Output = ExtendedPoint;
+
+    #[inline]
+    fn sub(self, other: &'b SubgroupPoint) -> ExtendedPoint {
+        self - other.0
+    }
+}
+
+impl_binops_additive!(ExtendedPoint, SubgroupPoint);
+
+impl<'a, 'b> Add<&'b SubgroupPoint> for &'a SubgroupPoint {
+    type Output = SubgroupPoint;
+
+    #[inline]
+    fn add(self, other: &'b SubgroupPoint) -> SubgroupPoint {
+        SubgroupPoint(self.0 + other.0)
+    }
+}
+
+impl<'a, 'b> Sub<&'b SubgroupPoint> for &'a SubgroupPoint {
+    type Output = SubgroupPoint;
+
+    #[inline]
+    fn sub(self, other: &'b SubgroupPoint) -> SubgroupPoint {
+        SubgroupPoint(self.0 - other.0)
+    }
+}
+
+impl_binops_additive!(SubgroupPoint, SubgroupPoint);
+
+impl<'a, 'b> Mul<&'b Fr> for &'a SubgroupPoint {
+    type Output = SubgroupPoint;
+
+    fn mul(self, other: &'b Fr) -> SubgroupPoint {
+        SubgroupPoint(self.0.multiply(&other.to_bytes()))
+    }
+}
+
+impl_binops_multiplicative!(SubgroupPoint, Fr);
+
+impl Group for ExtendedPoint {
+    type Scalar = Fr;
+
+    fn random(mut rng: impl RngCore) -> Self {
+        loop {
+            let v = Fq::random(&mut rng);
+            let flip_sign = rng.next_u32() % 2 != 0;
+
+            // See AffinePoint::from_bytes for details.
+            let v2 = v.square();
+            let p = ((v2 - Fq::one())
+                * ((Fq::one() + EDWARDS_D * v2)
+                    .invert()
+                    .unwrap_or(Fq::zero())))
+            .sqrt()
+            .map(|u| AffinePoint {
+                u: if flip_sign { -u } else { u },
+                v,
+            });
+
+            if p.is_some().into() {
+                let p = p.unwrap().to_curve();
+
+                if bool::from(!p.is_identity()) {
+                    return p;
+                }
+            }
+        }
+    }
+
+    fn identity() -> Self {
+        Self::identity()
+    }
+
+    fn generator() -> Self {
+        AffinePoint::generator().into()
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.is_identity()
+    }
+
+    #[must_use]
+    fn double(&self) -> Self {
+        self.double()
+    }
+}
+
+impl Group for SubgroupPoint {
+    type Scalar = Fr;
+
+    fn random(mut rng: impl RngCore) -> Self {
+        loop {
+            let p = ExtendedPoint::random(&mut rng).clear_cofactor();
+
+            if bool::from(!p.is_identity()) {
+                return p;
+            }
+        }
+    }
+
+    fn identity() -> Self {
+        SubgroupPoint(ExtendedPoint::identity())
+    }
+
+    fn generator() -> Self {
+        ExtendedPoint::generator().clear_cofactor()
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.0.is_identity()
+    }
+
+    #[must_use]
+    fn double(&self) -> Self {
+        SubgroupPoint(self.0.double())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl WnafGroup for ExtendedPoint {
+    fn recommended_wnaf_for_num_scalars(num_scalars: usize) -> usize {
+        // Copied from bls12_381::g1, should be updated.
+        const RECOMMENDATIONS: [usize; 12] =
+            [1, 3, 7, 20, 43, 120, 273, 563, 1630, 3128, 7933, 62569];
+
+        let mut ret = 4;
+        for r in &RECOMMENDATIONS {
+            if num_scalars > *r {
+                ret += 1;
+            } else {
+                break;
+            }
+        }
+
+        ret
+    }
+}
+
+impl PrimeGroup for SubgroupPoint {}
+
+impl CofactorGroup for ExtendedPoint {
+    type Subgroup = SubgroupPoint;
+
+    fn clear_cofactor(&self) -> Self::Subgroup {
+        SubgroupPoint(self.mul_by_cofactor())
+    }
+
+    fn into_subgroup(self) -> CtOption<Self::Subgroup> {
+        CtOption::new(SubgroupPoint(self), self.is_torsion_free())
+    }
+
+    fn is_torsion_free(&self) -> Choice {
+        self.is_torsion_free()
+    }
+}
+
+impl Curve for ExtendedPoint {
+    type AffineRepr = AffinePoint;
+
+    fn batch_normalize(p: &[Self], q: &mut [Self::AffineRepr]) {
+        Self::batch_normalize(p, q);
+    }
+
+    fn to_affine(&self) -> Self::AffineRepr {
+        self.into()
+    }
+}
+
+impl CofactorCurve for ExtendedPoint {
+    type Affine = AffinePoint;
+}
+
+impl CofactorCurveAffine for AffinePoint {
+    type Scalar = Fr;
+    type Curve = ExtendedPoint;
+
+    fn identity() -> Self {
+        Self::identity()
+    }
+
+    fn generator() -> Self {
+        // The point with the lowest positive v-coordinate and positive
+        // u-coordinate.
+        AffinePoint {
+            u: Fq::from_raw([
+                0xe4b3_d35d_f1a7_adfe,
+                0xcaf5_5d1b_29bf_81af,
+                0x8b0f_03dd_d60a_8187,
+                0x62ed_cbb8_bf37_87c8,
+            ]),
+            v: Fq::from_raw([
+                0x0000_0000_0000_000b,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+            ]),
+        }
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.is_identity()
+    }
+
+    fn to_curve(&self) -> Self::Curve {
+        (*self).into()
+    }
+}
+
+impl GroupEncoding for ExtendedPoint {
+    type Repr = [u8; 32];
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        AffinePoint::from_bytes(*bytes).map(Self::from)
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        // We can't avoid curve checks when parsing a compressed encoding.
+        AffinePoint::from_bytes(*bytes).map(Self::from)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        AffinePoint::from(self).to_bytes()
+    }
+}
+
+impl GroupEncoding for SubgroupPoint {
+    type Repr = [u8; 32];
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        ExtendedPoint::from_bytes(bytes).and_then(|p| p.into_subgroup())
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        ExtendedPoint::from_bytes_unchecked(bytes).map(SubgroupPoint)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.0.to_bytes()
+    }
+}
+
+impl GroupEncoding for AffinePoint {
+    type Repr = [u8; 32];
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        Self::from_bytes(*bytes)
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        Self::from_bytes(*bytes)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.to_bytes()
+    }
 }
 
 #[test]
 fn test_is_on_curve_var() {
-    assert!(JubJubAffine::identity().is_on_curve_vartime());
-}
-
-#[test]
-fn test_affine_point_generator_has_order_p() {
-    assert_eq!(GENERATOR.is_prime_order().unwrap_u8(), 1);
-}
-
-#[test]
-fn test_extended_point_generator_has_order_p() {
-    assert_eq!(GENERATOR_EXTENDED.is_prime_order().unwrap_u8(), 1);
-}
-
-#[test]
-fn test_affine_point_generator_nums_has_order_p() {
-    assert_eq!(GENERATOR_NUMS.is_prime_order().unwrap_u8(), 1);
-}
-
-#[test]
-fn test_affine_point_generator_is_not_identity() {
-    assert_ne!(
-        JubJubExtended::from(GENERATOR.mul_by_cofactor()),
-        JubJubExtended::identity()
-    );
-}
-
-#[test]
-fn test_extended_point_generator_is_not_identity() {
-    assert_ne!(
-        GENERATOR_EXTENDED.mul_by_cofactor(),
-        JubJubExtended::identity()
-    );
-}
-
-#[test]
-fn test_affine_point_generator_nums_is_not_identity() {
-    assert_ne!(
-        JubJubExtended::from(GENERATOR_NUMS.mul_by_cofactor()),
-        JubJubExtended::identity()
-    );
+    assert!(AffinePoint::identity().is_on_curve_vartime());
 }
 
 #[test]
 fn test_d_is_non_quadratic_residue() {
-    assert!(EDWARDS_D.sqrt().is_none().unwrap_u8() == 1);
-    assert!((-EDWARDS_D).sqrt().is_none().unwrap_u8() == 1);
-    assert!((-EDWARDS_D).invert().unwrap().sqrt().is_none().unwrap_u8() == 1);
+    assert!(bool::from(EDWARDS_D.sqrt().is_none()));
+    assert!(bool::from((-EDWARDS_D).sqrt().is_none()));
+    assert!(bool::from((-EDWARDS_D).invert().unwrap().sqrt().is_none()));
 }
 
 #[test]
 fn test_affine_niels_point_identity() {
     assert_eq!(
-        AffineNielsPoint::identity().y_plus_x,
-        JubJubAffine::identity().to_niels().y_plus_x
+        AffineNielsPoint::identity().v_plus_u,
+        AffinePoint::identity().to_niels().v_plus_u
     );
     assert_eq!(
-        AffineNielsPoint::identity().y_minus_x,
-        JubJubAffine::identity().to_niels().y_minus_x
+        AffineNielsPoint::identity().v_minus_u,
+        AffinePoint::identity().to_niels().v_minus_u
     );
     assert_eq!(
         AffineNielsPoint::identity().t2d,
-        JubJubAffine::identity().to_niels().t2d
+        AffinePoint::identity().to_niels().t2d
     );
 }
 
 #[test]
 fn test_extended_niels_point_identity() {
     assert_eq!(
-        ExtendedNielsPoint::identity().y_plus_x,
-        JubJubExtended::identity().to_niels().y_plus_x
+        ExtendedNielsPoint::identity().v_plus_u,
+        ExtendedPoint::identity().to_niels().v_plus_u
     );
     assert_eq!(
-        ExtendedNielsPoint::identity().y_minus_x,
-        JubJubExtended::identity().to_niels().y_minus_x
+        ExtendedNielsPoint::identity().v_minus_u,
+        ExtendedPoint::identity().to_niels().v_minus_u
     );
     assert_eq!(
         ExtendedNielsPoint::identity().z,
-        JubJubExtended::identity().to_niels().z
+        ExtendedPoint::identity().to_niels().z
     );
     assert_eq!(
         ExtendedNielsPoint::identity().t2d,
-        JubJubExtended::identity().to_niels().t2d
+        ExtendedPoint::identity().to_niels().t2d
     );
 }
 
 #[test]
 fn test_assoc() {
-    let p = JubJubExtended::from(JubJubAffine {
-        x: BlsScalar::from_raw([
-            0x81c571e5d883cfb0,
-            0x049f7a686f147029,
-            0xf539c860bc3ea21f,
-            0x4284715b7ccc8162,
+    let p = ExtendedPoint::from(AffinePoint {
+        u: Fq::from_raw([
+            0x81c5_71e5_d883_cfb0,
+            0x049f_7a68_6f14_7029,
+            0xf539_c860_bc3e_a21f,
+            0x4284_715b_7ccc_8162,
         ]),
-        y: BlsScalar::from_raw([
-            0xbf096275684bb8ca,
-            0xc7ba245890af256d,
-            0x59119f3e86380eb0,
-            0x3793de182f9fb1d2,
+        v: Fq::from_raw([
+            0xbf09_6275_684b_b8ca,
+            0xc7ba_2458_90af_256d,
+            0x5911_9f3e_8638_0eb0,
+            0x3793_de18_2f9f_b1d2,
         ]),
     })
     .mul_by_cofactor();
@@ -1211,161 +1603,166 @@ fn test_assoc() {
 
 #[test]
 fn test_batch_normalize() {
-    let mut p = JubJubExtended::from(JubJubAffine {
-        x: BlsScalar::from_raw([
-            0x81c571e5d883cfb0,
-            0x049f7a686f147029,
-            0xf539c860bc3ea21f,
-            0x4284715b7ccc8162,
+    let mut p = ExtendedPoint::from(AffinePoint {
+        u: Fq::from_raw([
+            0x81c5_71e5_d883_cfb0,
+            0x049f_7a68_6f14_7029,
+            0xf539_c860_bc3e_a21f,
+            0x4284_715b_7ccc_8162,
         ]),
-        y: BlsScalar::from_raw([
-            0xbf096275684bb8ca,
-            0xc7ba245890af256d,
-            0x59119f3e86380eb0,
-            0x3793de182f9fb1d2,
+        v: Fq::from_raw([
+            0xbf09_6275_684b_b8ca,
+            0xc7ba_2458_90af_256d,
+            0x5911_9f3e_8638_0eb0,
+            0x3793_de18_2f9f_b1d2,
         ]),
     })
     .mul_by_cofactor();
 
-    let mut y = vec![];
+    let mut v = vec![];
     for _ in 0..10 {
-        y.push(p);
+        v.push(p);
         p = p.double();
     }
 
-    for p in &y {
+    for p in &v {
         assert!(p.is_on_curve_vartime());
     }
 
     let expected: std::vec::Vec<_> =
-        y.iter().map(|p| JubJubAffine::from(*p)).collect();
-    let result1: std::vec::Vec<_> = batch_normalize(&mut y).collect();
+        v.iter().map(|p| AffinePoint::from(*p)).collect();
+    let mut result0 = vec![AffinePoint::identity(); v.len()];
+    ExtendedPoint::batch_normalize(&v, &mut result0);
+    for i in 0..10 {
+        assert!(expected[i] == result0[i]);
+    }
+    let result1: std::vec::Vec<_> = batch_normalize(&mut v).collect();
     for i in 0..10 {
         assert!(expected[i] == result1[i]);
-        assert!(y[i].is_on_curve_vartime());
-        assert!(JubJubAffine::from(y[i]) == expected[i]);
+        assert!(v[i].is_on_curve_vartime());
+        assert!(AffinePoint::from(v[i]) == expected[i]);
     }
-    let result2: std::vec::Vec<_> = batch_normalize(&mut y).collect();
+    let result2: std::vec::Vec<_> = batch_normalize(&mut v).collect();
     for i in 0..10 {
         assert!(expected[i] == result2[i]);
-        assert!(y[i].is_on_curve_vartime());
-        assert!(JubJubAffine::from(y[i]) == expected[i]);
+        assert!(v[i].is_on_curve_vartime());
+        assert!(AffinePoint::from(v[i]) == expected[i]);
     }
 }
 
 #[cfg(test)]
-const FULL_GENERATOR: JubJubAffine = JubJubAffine::from_raw_unchecked(
-    BlsScalar::from_raw([
-        0xe4b3d35df1a7adfe,
-        0xcaf55d1b29bf81af,
-        0x8b0f03ddd60a8187,
-        0x62edcbb8bf3787c8,
+const FULL_GENERATOR: AffinePoint = AffinePoint::from_raw_unchecked(
+    Fq::from_raw([
+        0xe4b3_d35d_f1a7_adfe,
+        0xcaf5_5d1b_29bf_81af,
+        0x8b0f_03dd_d60a_8187,
+        0x62ed_cbb8_bf37_87c8,
     ]),
-    BlsScalar::from_raw([0xb, 0x0, 0x0, 0x0]),
+    Fq::from_raw([0xb, 0x0, 0x0, 0x0]),
 );
 
 #[cfg(test)]
-const EIGHT_TORSION: [JubJubAffine; 8] = [
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([
-            0xd92e6a7927200d43,
-            0x7aa41ac43dae8582,
-            0xeaaae086a16618d1,
-            0x71d4df38ba9e7973,
+const EIGHT_TORSION: [AffinePoint; 8] = [
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([
+            0xd92e_6a79_2720_0d43,
+            0x7aa4_1ac4_3dae_8582,
+            0xeaaa_e086_a166_18d1,
+            0x71d4_df38_ba9e_7973,
         ]),
-        BlsScalar::from_raw([
-            0xff0d2068eff496dd,
-            0x9106ee90f384a4a1,
-            0x16a13035ad4d7266,
-            0x4958bdb21966982e,
-        ]),
-    ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([
-            0xfffeffff00000001,
-            0x67baa40089fb5bfe,
-            0xa5e80b39939ed334,
-            0x73eda753299d7d47,
-        ]),
-        BlsScalar::from_raw([0x0, 0x0, 0x0, 0x0]),
-    ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([
-            0xd92e6a7927200d43,
-            0x7aa41ac43dae8582,
-            0xeaaae086a16618d1,
-            0x71d4df38ba9e7973,
-        ]),
-        BlsScalar::from_raw([
-            0xf2df96100b6924,
-            0xc2b6b5720c79b75d,
-            0x1c98a7d25c54659e,
-            0x2a94e9a11036e51a,
+        Fq::from_raw([
+            0xff0d_2068_eff4_96dd,
+            0x9106_ee90_f384_a4a1,
+            0x16a1_3035_ad4d_7266,
+            0x4958_bdb2_1966_982e,
         ]),
     ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([0x0, 0x0, 0x0, 0x0]),
-        BlsScalar::from_raw([
-            0xffffffff00000000,
-            0x53bda402fffe5bfe,
-            0x3339d80809a1d805,
-            0x73eda753299d7d48,
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([
+            0xfffe_ffff_0000_0001,
+            0x67ba_a400_89fb_5bfe,
+            0xa5e8_0b39_939e_d334,
+            0x73ed_a753_299d_7d47,
+        ]),
+        Fq::from_raw([0x0, 0x0, 0x0, 0x0]),
+    ),
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([
+            0xd92e_6a79_2720_0d43,
+            0x7aa4_1ac4_3dae_8582,
+            0xeaaa_e086_a166_18d1,
+            0x71d4_df38_ba9e_7973,
+        ]),
+        Fq::from_raw([
+            0x00f2_df96_100b_6924,
+            0xc2b6_b572_0c79_b75d,
+            0x1c98_a7d2_5c54_659e,
+            0x2a94_e9a1_1036_e51a,
         ]),
     ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([
-            0x26d19585d8dff2be,
-            0xd919893ec24fd67c,
-            0x488ef781683bbf33,
-            0x218c81a6eff03d4,
-        ]),
-        BlsScalar::from_raw([
-            0xf2df96100b6924,
-            0xc2b6b5720c79b75d,
-            0x1c98a7d25c54659e,
-            0x2a94e9a11036e51a,
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([0x0, 0x0, 0x0, 0x0]),
+        Fq::from_raw([
+            0xffff_ffff_0000_0000,
+            0x53bd_a402_fffe_5bfe,
+            0x3339_d808_09a1_d805,
+            0x73ed_a753_299d_7d48,
         ]),
     ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([
-            0x1000000000000,
-            0xec03000276030000,
-            0x8d51ccce760304d0,
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([
+            0x26d1_9585_d8df_f2be,
+            0xd919_893e_c24f_d67c,
+            0x488e_f781_683b_bf33,
+            0x0218_c81a_6eff_03d4,
+        ]),
+        Fq::from_raw([
+            0x00f2_df96_100b_6924,
+            0xc2b6_b572_0c79_b75d,
+            0x1c98_a7d2_5c54_659e,
+            0x2a94_e9a1_1036_e51a,
+        ]),
+    ),
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([
+            0x0001_0000_0000_0000,
+            0xec03_0002_7603_0000,
+            0x8d51_ccce_7603_04d0,
             0x0,
         ]),
-        BlsScalar::from_raw([0x0, 0x0, 0x0, 0x0]),
+        Fq::from_raw([0x0, 0x0, 0x0, 0x0]),
     ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([
-            0x26d19585d8dff2be,
-            0xd919893ec24fd67c,
-            0x488ef781683bbf33,
-            0x218c81a6eff03d4,
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([
+            0x26d1_9585_d8df_f2be,
+            0xd919_893e_c24f_d67c,
+            0x488e_f781_683b_bf33,
+            0x0218_c81a_6eff_03d4,
         ]),
-        BlsScalar::from_raw([
-            0xff0d2068eff496dd,
-            0x9106ee90f384a4a1,
-            0x16a13035ad4d7266,
-            0x4958bdb21966982e,
+        Fq::from_raw([
+            0xff0d_2068_eff4_96dd,
+            0x9106_ee90_f384_a4a1,
+            0x16a1_3035_ad4d_7266,
+            0x4958_bdb2_1966_982e,
         ]),
     ),
-    JubJubAffine::from_raw_unchecked(
-        BlsScalar::from_raw([0x0, 0x0, 0x0, 0x0]),
-        BlsScalar::from_raw([0x1, 0x0, 0x0, 0x0]),
+    AffinePoint::from_raw_unchecked(
+        Fq::from_raw([0x0, 0x0, 0x0, 0x0]),
+        Fq::from_raw([0x1, 0x0, 0x0, 0x0]),
     ),
 ];
 
 #[test]
 fn find_eight_torsion() {
-    let g = JubJubExtended::from(FULL_GENERATOR);
-    assert!(g.is_small_order().unwrap_u8() == 0);
+    let g = ExtendedPoint::from(FULL_GENERATOR);
+    assert!(!bool::from(g.is_small_order()));
     let g = g.multiply(&FR_MODULUS_BYTES);
-    assert!(g.is_small_order().unwrap_u8() == 1);
+    assert!(bool::from(g.is_small_order()));
 
     let mut cur = g;
 
     for (i, point) in EIGHT_TORSION.iter().enumerate() {
-        let tmp = JubJubAffine::from(cur);
+        let tmp = AffinePoint::from(cur);
         if &tmp != point {
             panic!("{}th torsion point should be {:?}", i, tmp);
         }
@@ -1378,23 +1775,24 @@ fn find_eight_torsion() {
 fn find_curve_generator() {
     let mut trial_bytes = [0; 32];
     for _ in 0..255 {
-        let a = JubJubAffine::from_bytes(&trial_bytes);
-        if a.is_ok() {
+        let a = AffinePoint::from_bytes(trial_bytes);
+        if bool::from(a.is_some()) {
             let a = a.unwrap();
             assert!(a.is_on_curve_vartime());
-            let b = JubJubExtended::from(a);
+            let b = ExtendedPoint::from(a);
             let b = b.multiply(&FR_MODULUS_BYTES);
-            assert!(b.is_small_order().unwrap_u8() == 1);
+            assert!(bool::from(b.is_small_order()));
             let b = b.double();
-            assert!(b.is_small_order().unwrap_u8() == 1);
+            assert!(bool::from(b.is_small_order()));
             let b = b.double();
-            assert!(b.is_small_order().unwrap_u8() == 1);
-            if b.is_identity().unwrap_u8() == 0 {
+            assert!(bool::from(b.is_small_order()));
+            if !bool::from(b.is_identity()) {
                 let b = b.double();
-                assert!(b.is_small_order().unwrap_u8() == 1);
-                assert!(b.is_identity().unwrap_u8() == 1);
+                assert!(bool::from(b.is_small_order()));
+                assert!(bool::from(b.is_identity()));
                 assert_eq!(FULL_GENERATOR, a);
-                assert!(a.mul_by_cofactor().is_torsion_free().unwrap_u8() == 1);
+                assert_eq!(AffinePoint::generator(), a);
+                assert!(bool::from(a.mul_by_cofactor().is_torsion_free()));
                 return;
             }
         }
@@ -1408,35 +1806,7 @@ fn find_curve_generator() {
 #[test]
 fn test_small_order() {
     for point in EIGHT_TORSION.iter() {
-        assert!(point.is_small_order().unwrap_u8() == 1);
-    }
-}
-
-#[ignore]
-#[test]
-fn second_gen_nums() {
-    use blake2::{Blake2b, Digest};
-    let generator_bytes = GENERATOR.to_bytes();
-    let mut counter = 0u64;
-    let mut array = [0u8; 32];
-    loop {
-        let mut hasher = Blake2b::new();
-        hasher.update(generator_bytes);
-        hasher.update(counter.to_le_bytes());
-        let res = hasher.finalize();
-        array.copy_from_slice(&res[0..32]);
-        if JubJubAffine::from_bytes(&array).is_ok()
-            && JubJubAffine::from_bytes(&array)
-                .unwrap()
-                .is_prime_order()
-                .unwrap_u8()
-                == 1
-        {
-            assert!(
-                GENERATOR_NUMS == JubJubAffine::from_bytes(&array).unwrap()
-            );
-        }
-        counter += 1;
+        assert!(bool::from(point.is_small_order()));
     }
 }
 
@@ -1445,53 +1815,53 @@ fn test_is_identity() {
     let a = EIGHT_TORSION[0].mul_by_cofactor();
     let b = EIGHT_TORSION[1].mul_by_cofactor();
 
-    assert_eq!(a.x, b.x);
-    assert_eq!(a.y, a.z);
-    assert_eq!(b.y, b.z);
-    assert!(a.y != b.y);
+    assert_eq!(a.u, b.u);
+    assert_eq!(a.v, a.z);
+    assert_eq!(b.v, b.z);
+    assert!(a.v != b.v);
     assert!(a.z != b.z);
 
-    assert!(a.is_identity().unwrap_u8() == 1);
-    assert!(b.is_identity().unwrap_u8() == 1);
+    assert!(bool::from(a.is_identity()));
+    assert!(bool::from(b.is_identity()));
 
     for point in EIGHT_TORSION.iter() {
-        assert!(point.mul_by_cofactor().is_identity().unwrap_u8() == 1);
+        assert!(bool::from(point.mul_by_cofactor().is_identity()));
     }
 }
 
 #[test]
 fn test_mul_consistency() {
     let a = Fr([
-        0x21e61211d9934f2e,
-        0xa52c058a693c3e07,
-        0x9ccb77bfb12d6360,
-        0x07df2470ec94398e,
+        0x21e6_1211_d993_4f2e,
+        0xa52c_058a_693c_3e07,
+        0x9ccb_77bf_b12d_6360,
+        0x07df_2470_ec94_398e,
     ]);
     let b = Fr([
-        0x03336d1cbe19dbe0,
-        0x0153618f6156a536,
-        0x2604c9e1fc3c6b15,
-        0x04ae581ceb028720,
+        0x0333_6d1c_be19_dbe0,
+        0x0153_618f_6156_a536,
+        0x2604_c9e1_fc3c_6b15,
+        0x04ae_581c_eb02_8720,
     ]);
     let c = Fr([
-        0xd7abf5bb24683f4c,
-        0x9d7712cc274b7c03,
-        0x973293db9683789f,
-        0x0b677e29380a97a7,
+        0xd7ab_f5bb_2468_3f4c,
+        0x9d77_12cc_274b_7c03,
+        0x9732_93db_9683_789f,
+        0x0b67_7e29_380a_97a7,
     ]);
     assert_eq!(a * b, c);
-    let p = JubJubExtended::from(JubJubAffine {
-        x: BlsScalar::from_raw([
-            0x81c571e5d883cfb0,
-            0x049f7a686f147029,
-            0xf539c860bc3ea21f,
-            0x4284715b7ccc8162,
+    let p = ExtendedPoint::from(AffinePoint {
+        u: Fq::from_raw([
+            0x81c5_71e5_d883_cfb0,
+            0x049f_7a68_6f14_7029,
+            0xf539_c860_bc3e_a21f,
+            0x4284_715b_7ccc_8162,
         ]),
-        y: BlsScalar::from_raw([
-            0xbf096275684bb8ca,
-            0xc7ba245890af256d,
-            0x59119f3e86380eb0,
-            0x3793de182f9fb1d2,
+        v: Fq::from_raw([
+            0xbf09_6275_684b_b8ca,
+            0xc7ba_2458_90af_256d,
+            0x5911_9f3e_8638_0eb0,
+            0x3793_de18_2f9f_b1d2,
         ]),
     })
     .mul_by_cofactor();
@@ -1503,18 +1873,19 @@ fn test_mul_consistency() {
     assert_eq!(p.to_niels() * c, (p.to_niels() * a) * b);
 
     // Test Mul implemented on AffineNielsPoint
-    let p_affine_niels = JubJubAffine::from(p).to_niels();
+    let p_affine_niels = AffinePoint::from(p).to_niels();
     assert_eq!(p * c, (p_affine_niels * a) * b);
     assert_eq!(p_affine_niels * c, (p * a) * b);
     assert_eq!(p_affine_niels * c, (p_affine_niels * a) * b);
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_serialization_consistency() {
     let gen = FULL_GENERATOR.mul_by_cofactor();
     let mut p = gen;
 
-    let y = vec![
+    let v = vec![
         [
             203, 85, 12, 213, 56, 234, 12, 193, 19, 132, 128, 64, 142, 110,
             170, 185, 179, 108, 97, 63, 13, 211, 247, 120, 79, 219, 110, 234,
@@ -1597,20 +1968,20 @@ fn test_serialization_consistency() {
         ],
     ];
 
-    for expected_serialized in y {
-        assert!(p.is_on_curve_vartime());
-        let affine = JubJubAffine::from(p);
-        let serialized = affine.to_bytes();
-        let deserialized = JubJubAffine::from_bytes(&serialized).unwrap();
-        assert_eq!(affine, deserialized);
-        assert_eq!(expected_serialized, serialized);
-        p = p + &gen;
-    }
-}
+    let batched = AffinePoint::batch_from_bytes(v.iter().cloned());
 
-/// Compute a shared secret `secret · public` using DHKE protocol
-pub fn dhke(secret: &Fr, public: &JubJubExtended) -> JubJubAffine {
-    public.mul(secret).into()
+    for (expected_serialized, batch_deserialized) in
+        v.into_iter().zip(batched.into_iter())
+    {
+        assert!(p.is_on_curve_vartime());
+        let affine = AffinePoint::from(p);
+        let serialized = affine.to_bytes();
+        let deserialized = AffinePoint::from_bytes(serialized).unwrap();
+        assert_eq!(affine, deserialized);
+        assert_eq!(affine, batch_deserialized.unwrap());
+        assert_eq!(expected_serialized, serialized);
+        p += gen;
+    }
 }
 
 #[test]
@@ -1631,14 +2002,321 @@ fn test_zip_216() {
     ];
 
     for b in &NON_CANONICAL_ENCODINGS {
-        let mut encoding = *b;
+        {
+            let mut encoding = *b;
 
-        // The normal API should reject the non-canonical encoding.
-        assert!(bool::from(JubJubAffine::from_bytes(&encoding).is_err()));
+            // The normal API should reject the non-canonical encoding.
+            assert!(bool::from(AffinePoint::from_bytes(encoding).is_none()));
 
-        // If we clear the sign bit of the non-canonical encoding, it should
-        // be accepted by the normal API.
-        encoding[31] &= 0b0111_1111;
-        assert!(bool::from(JubJubAffine::from_bytes(&encoding).is_ok()));
+            // If we clear the sign bit of the non-canonical encoding, it should
+            // be accepted by the normal API.
+            encoding[31] &= 0b0111_1111;
+            assert!(bool::from(AffinePoint::from_bytes(encoding).is_some()));
+        }
+
+        {
+            // The bug-preserving API should accept the non-canonical encoding,
+            // and the resulting point should serialize to a
+            // different (canonical) encoding.
+            let parsed =
+                AffinePoint::from_bytes_pre_zip216_compatibility(*b).unwrap();
+            let mut encoded = parsed.to_bytes();
+            assert_ne!(b, &encoded);
+
+            // If we set the sign bit of the serialized encoding, it should
+            // match the non-canonical encoding.
+            encoded[31] |= 0b1000_0000;
+            assert_eq!(b, &encoded);
+        }
     }
 }
+
+// Dusk Network features
+mod dusk {
+    use super::*;
+
+    use dusk_bytes::{Error as BytesError, Serializable};
+
+    pub use dusk_bls12_381::BlsScalar;
+
+    /// An alias for [`AffinePoint`]
+    pub type JubJubAffine = AffinePoint;
+    /// An alias for [`ExtendedPoint`]
+    pub type JubJubExtended = ExtendedPoint;
+    /// An alias for [`Fr`].
+    pub type JubJubScalar = Fr;
+
+    /// Compute a shared secret `secret · public` using DHKE protocol
+    pub fn dhke(secret: &Fr, public: &JubJubExtended) -> JubJubAffine {
+        public.mul(secret).into()
+    }
+
+    /// Use a fixed generator point.
+    /// The point is then reduced according to the prime field. We need only to
+    /// state the coordinates, so users can exploit its properties
+    /// which are proven by tests, checking:
+    /// - It lies on the curve,
+    /// - Is of prime order,
+    /// - Is not the identity point.
+    /// Using:
+    ///     x = 0x3fd2814c43ac65a6f1fbf02d0fd6cce62e3ebb21fd6c54ed4df7b7ffec7beaca
+    //      y = 0x0000000000000000000000000000000000000000000000000000000000000012
+    pub const GENERATOR: JubJubAffine = JubJubAffine {
+        u: BlsScalar::from_raw([
+            0x4df7b7ffec7beaca,
+            0x2e3ebb21fd6c54ed,
+            0xf1fbf02d0fd6cce6,
+            0x3fd2814c43ac65a6,
+        ]),
+        v: BlsScalar::from_raw([
+            0x0000000000000012,
+            000000000000000000,
+            000000000000000000,
+            000000000000,
+        ]),
+    };
+
+    /// [`GENERATOR`] in [`JubJubExtended`] form
+    pub const GENERATOR_EXTENDED: JubJubExtended = JubJubExtended {
+        u: GENERATOR.u,
+        v: GENERATOR.v,
+        z: BlsScalar::one(),
+        t1: GENERATOR.u,
+        t2: GENERATOR.v,
+    };
+
+    /// GENERATOR NUMS which is obtained following the specs in:
+    /// https://app.gitbook.com/@dusk-network/s/specs/specifications/poseidon/pedersen-commitment-scheme
+    /// The counter = 18 and the hash function used to compute it was blake2b
+    /// Using:
+    ///     x = 0x5e67b8f316f414f7bd9514c773fd4456931e316a39fe4541921710179df76377
+    //      y = 0x43d80eb3b2f3eb1b7b162dbeeb3b34fd9949ba0f82a5507a6705b707162e3ef8
+    pub const GENERATOR_NUMS: JubJubAffine = JubJubAffine {
+        u: BlsScalar::from_raw([
+            0x921710179df76377,
+            0x931e316a39fe4541,
+            0xbd9514c773fd4456,
+            0x5e67b8f316f414f7,
+        ]),
+        v: BlsScalar::from_raw([
+            0x6705b707162e3ef8,
+            0x9949ba0f82a5507a,
+            0x7b162dbeeb3b34fd,
+            0x43d80eb3b2f3eb1b,
+        ]),
+    };
+
+    /// [`GENERATOR_NUMS`] in [`JubJubExtended`] form
+    pub const GENERATOR_NUMS_EXTENDED: JubJubExtended = JubJubExtended {
+        u: GENERATOR_NUMS.u,
+        v: GENERATOR_NUMS.v,
+        z: BlsScalar::one(),
+        t1: GENERATOR_NUMS.u,
+        t2: GENERATOR_NUMS.v,
+    };
+
+    impl Serializable<32> for JubJubAffine {
+        type Error = BytesError;
+
+        /// Attempts to interpret a byte representation of an
+        /// affine point, failing if the element is not on
+        /// the curve or non-canonical.
+        ///
+        /// NOTE: ZIP 216 is enabled by default and the only way to interact
+        /// with serialization.
+        /// See: <https://zips.z.cash/zip-0216> for more details.
+        fn from_bytes(b: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
+            let mut b = b.clone();
+
+            // Grab the sign bit from the representation
+            let sign = b[31] >> 7;
+
+            // Mask away the sign bit
+            b[31] &= 0b0111_1111;
+
+            // Interpret what remains as the y-coordinate
+            let v = <BlsScalar as Serializable<32>>::from_bytes(&b)?;
+
+            // -x^2 + y^2 = 1 + d.x^2.y^2
+            // -x^2 = 1 + d.x^2.y^2 - y^2    (rearrange)
+            // -x^2 - d.x^2.y^2 = 1 - y^2    (rearrange)
+            // x^2 + d.x^2.y^2 = y^2 - 1     (flip signs)
+            // x^2 (1 + d.y^2) = y^2 - 1     (factor)
+            // x^2 = (y^2 - 1) / (1 + d.y^2) (isolate x^2)
+            // We know that (1 + d.y^2) is nonzero for all y:
+            //   (1 + d.y^2) = 0
+            //   d.y^2 = -1
+            //   y^2 = -(1 / d)   No solutions, as -(1 / d) is not a square
+
+            let v2 = v.square();
+
+            Option::from(
+                ((v2 - BlsScalar::one())
+                    * ((BlsScalar::one() + EDWARDS_D * &v2)
+                        .invert()
+                        .unwrap_or(BlsScalar::zero())))
+                .sqrt()
+                .and_then(|u| {
+                    // Fix the sign of `x` if necessary
+                    let flip_sign = Choice::from((u.to_bytes()[0] ^ sign) & 1);
+                    let u = BlsScalar::conditional_select(&u, &-u, flip_sign);
+                    // If x == 0, flip_sign == sign_bit. We therefore want to
+                    // reject the encoding as non-canonical
+                    // if all of the following occur:
+                    // - x == 0
+                    // - flip_sign == true
+                    let u_is_zero = u.ct_eq(&BlsScalar::zero());
+                    CtOption::new(
+                        JubJubAffine { u, v },
+                        !(u_is_zero & flip_sign),
+                    )
+                }),
+            )
+            .ok_or(BytesError::InvalidData)
+        }
+
+        /// Converts this element into its byte representation.
+        fn to_bytes(&self) -> [u8; Self::SIZE] {
+            let mut tmp = self.v.to_bytes();
+            let u = self.u.to_bytes();
+
+            // Encode the sign of the x-coordinate in the most
+            // significant bit.
+            tmp[31] |= u[0] << 7;
+
+            tmp
+        }
+    }
+
+    impl ExtendedPoint {
+        /// Constructs an extended point (with `Z = 1`) from
+        /// an affine point using the map `(x, y) => (x, y, 1, x, y)`.
+        pub const fn from_affine(affine: JubJubAffine) -> Self {
+            Self::from_raw_unchecked(
+                affine.u,
+                affine.v,
+                BlsScalar::one(),
+                affine.u,
+                affine.v,
+            )
+        }
+
+        /// Constructs an extended point from its raw internals
+        pub const fn from_raw_unchecked(
+            u: BlsScalar,
+            v: BlsScalar,
+            z: BlsScalar,
+            t1: BlsScalar,
+            t2: BlsScalar,
+        ) -> Self {
+            Self { u, v, z, t1, t2 }
+        }
+
+        /// Returns the `u`-coordinate of this point.
+        pub const fn get_u(&self) -> BlsScalar {
+            self.u
+        }
+
+        /// Returns the `v`-coordinate of this point.
+        pub const fn get_v(&self) -> BlsScalar {
+            self.v
+        }
+
+        /// Returns the `z`-coordinate of this point.
+        pub const fn get_z(&self) -> BlsScalar {
+            self.z
+        }
+
+        /// Returns the `t1`-coordinate of this point.
+        pub const fn get_t1(&self) -> BlsScalar {
+            self.t1
+        }
+
+        /// Returns the `t2`-coordinate of this point.
+        pub const fn get_t2(&self) -> BlsScalar {
+            self.t2
+        }
+
+        /// Returns two scalars suitable for hashing that represent the
+        /// Extended Point.
+        pub fn to_hash_inputs(&self) -> [BlsScalar; 2] {
+            // The same JubJubAffine can have different JubJubExtended
+            // representations, therefore we convert from Extended to Affine
+            // before hashing, to ensure deterministic result
+            let p = JubJubAffine::from(self);
+            [p.u, p.v]
+        }
+    }
+
+    #[test]
+    fn test_affine_point_generator_has_order_p() {
+        assert_eq!(GENERATOR.is_prime_order().unwrap_u8(), 1);
+    }
+
+    #[test]
+    fn test_extended_point_generator_has_order_p() {
+        assert_eq!(GENERATOR_EXTENDED.is_prime_order().unwrap_u8(), 1);
+    }
+
+    #[test]
+    fn test_affine_point_generator_nums_has_order_p() {
+        assert_eq!(GENERATOR_NUMS.is_prime_order().unwrap_u8(), 1);
+    }
+
+    #[test]
+    fn test_affine_point_generator_is_not_identity() {
+        assert_ne!(
+            JubJubExtended::from(GENERATOR.mul_by_cofactor()),
+            JubJubExtended::identity()
+        );
+    }
+
+    #[test]
+    fn test_extended_point_generator_is_not_identity() {
+        assert_ne!(
+            GENERATOR_EXTENDED.mul_by_cofactor(),
+            JubJubExtended::identity()
+        );
+    }
+
+    #[test]
+    fn test_affine_point_generator_nums_is_not_identity() {
+        assert_ne!(
+            JubJubExtended::from(GENERATOR_NUMS.mul_by_cofactor()),
+            JubJubExtended::identity()
+        );
+    }
+
+    #[ignore]
+    #[test]
+    fn second_gen_nums() {
+        use blake2::{Blake2b, Digest};
+        let generator_bytes = GENERATOR.to_bytes();
+        let mut counter = 0u64;
+        let mut array = [0u8; 32];
+        loop {
+            let mut hasher = Blake2b::new();
+            hasher.update(generator_bytes);
+            hasher.update(counter.to_le_bytes());
+            let res = hasher.finalize();
+            array.copy_from_slice(&res[0..32]);
+            if <JubJubAffine as Serializable<32>>::from_bytes(&array).is_ok()
+                && <JubJubAffine as Serializable<32>>::from_bytes(&array)
+                    .unwrap()
+                    .is_prime_order()
+                    .unwrap_u8()
+                    == 1
+            {
+                assert!(
+                    GENERATOR_NUMS
+                        == <JubJubAffine as Serializable<32>>::from_bytes(
+                            &array
+                        )
+                        .unwrap()
+                );
+            }
+            counter += 1;
+        }
+    }
+}
+pub use dusk::*;

--- a/tests/fq_blackbox.rs
+++ b/tests/fq_blackbox.rs
@@ -1,15 +1,14 @@
 mod common;
 
 use common::{new_rng, MyRandom, NUM_BLACK_BOX_CHECKS};
-use dusk_bytes::Serializable;
 use dusk_jubjub::*;
 
 #[test]
 fn test_to_and_from_bytes() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        assert_eq!(a, BlsScalar::from_bytes(&BlsScalar::to_bytes(&a)).unwrap());
+        let a = Fq::new_random(&mut rng);
+        assert_eq!(a, Fq::from_bytes(&Fq::to_bytes(&a)).unwrap());
     }
 }
 
@@ -17,9 +16,9 @@ fn test_to_and_from_bytes() {
 fn test_additive_associativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        let b = BlsScalar::new_random(&mut rng);
-        let c = BlsScalar::new_random(&mut rng);
+        let a = Fq::new_random(&mut rng);
+        let b = Fq::new_random(&mut rng);
+        let c = Fq::new_random(&mut rng);
         assert_eq!((a + b) + c, a + (b + c))
     }
 }
@@ -28,9 +27,9 @@ fn test_additive_associativity() {
 fn test_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        assert_eq!(a, a + BlsScalar::zero());
-        assert_eq!(a, BlsScalar::zero() + a);
+        let a = Fq::new_random(&mut rng);
+        assert_eq!(a, a + Fq::zero());
+        assert_eq!(a, Fq::zero() + a);
     }
 }
 
@@ -38,9 +37,9 @@ fn test_additive_identity() {
 fn test_subtract_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        assert_eq!(a, a - BlsScalar::zero());
-        assert_eq!(a, BlsScalar::zero() - -&a);
+        let a = Fq::new_random(&mut rng);
+        assert_eq!(a, a - Fq::zero());
+        assert_eq!(a, Fq::zero() - -&a);
     }
 }
 
@@ -48,19 +47,20 @@ fn test_subtract_additive_identity() {
 fn test_additive_inverse() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
+        let a = Fq::new_random(&mut rng);
         let a_neg = -&a;
-        assert_eq!(BlsScalar::zero(), a + a_neg);
-        assert_eq!(BlsScalar::zero(), a_neg + a);
+        assert_eq!(Fq::zero(), a + a_neg);
+        assert_eq!(Fq::zero(), a_neg + a);
     }
 }
 
+#[allow(clippy::eq_op)]
 #[test]
 fn test_additive_commutativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        let b = BlsScalar::new_random(&mut rng);
+        let a = Fq::new_random(&mut rng);
+        let b = Fq::new_random(&mut rng);
         assert_eq!(a + b, b + a);
     }
 }
@@ -69,9 +69,9 @@ fn test_additive_commutativity() {
 fn test_multiplicative_associativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        let b = BlsScalar::new_random(&mut rng);
-        let c = BlsScalar::new_random(&mut rng);
+        let a = Fq::new_random(&mut rng);
+        let b = Fq::new_random(&mut rng);
+        let c = Fq::new_random(&mut rng);
         assert_eq!((a * b) * c, a * (b * c))
     }
 }
@@ -80,9 +80,9 @@ fn test_multiplicative_associativity() {
 fn test_multiplicative_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        assert_eq!(a, a * BlsScalar::one());
-        assert_eq!(a, BlsScalar::one() * a);
+        let a = Fq::new_random(&mut rng);
+        assert_eq!(a, a * Fq::one());
+        assert_eq!(a, Fq::one() * a);
     }
 }
 
@@ -90,13 +90,13 @@ fn test_multiplicative_identity() {
 fn test_multiplicative_inverse() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        if a == BlsScalar::zero() {
+        let a = Fq::new_random(&mut rng);
+        if a == Fq::zero() {
             continue;
         }
         let a_inv = a.invert().unwrap();
-        assert_eq!(BlsScalar::one(), a * a_inv);
-        assert_eq!(BlsScalar::one(), a_inv * a);
+        assert_eq!(Fq::one(), a * a_inv);
+        assert_eq!(Fq::one(), a_inv * a);
     }
 }
 
@@ -104,8 +104,8 @@ fn test_multiplicative_inverse() {
 fn test_multiplicative_commutativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        let b = BlsScalar::new_random(&mut rng);
+        let a = Fq::new_random(&mut rng);
+        let b = Fq::new_random(&mut rng);
         assert_eq!(a * b, b * a);
     }
 }
@@ -114,8 +114,8 @@ fn test_multiplicative_commutativity() {
 fn test_multiply_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = BlsScalar::new_random(&mut rng);
-        assert_eq!(BlsScalar::zero(), BlsScalar::zero() * a);
-        assert_eq!(BlsScalar::zero(), a * BlsScalar::zero());
+        let a = Fq::new_random(&mut rng);
+        assert_eq!(Fq::zero(), Fq::zero() * a);
+        assert_eq!(Fq::zero(), a * Fq::zero());
     }
 }

--- a/tests/fr_blackbox.rs
+++ b/tests/fr_blackbox.rs
@@ -1,21 +1,14 @@
 mod common;
 
-use core::ops::Mul;
-
-use crate::BlsScalar;
 use common::{new_rng, MyRandom, NUM_BLACK_BOX_CHECKS};
-use dusk_bytes::Serializable;
 use dusk_jubjub::*;
 
 #[test]
 fn test_to_and_from_bytes() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        assert_eq!(
-            a,
-            JubJubScalar::from_bytes(&JubJubScalar::to_bytes(&a)).unwrap()
-        );
+        let a = Fr::new_random(&mut rng);
+        assert_eq!(a, Fr::from_bytes(&Fr::to_bytes(&a)).unwrap());
     }
 }
 
@@ -23,9 +16,9 @@ fn test_to_and_from_bytes() {
 fn test_additive_associativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        let b = JubJubScalar::new_random(&mut rng);
-        let c = JubJubScalar::new_random(&mut rng);
+        let a = Fr::new_random(&mut rng);
+        let b = Fr::new_random(&mut rng);
+        let c = Fr::new_random(&mut rng);
         assert_eq!((a + b) + c, a + (b + c))
     }
 }
@@ -34,9 +27,9 @@ fn test_additive_associativity() {
 fn test_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        assert_eq!(a, a + JubJubScalar::zero());
-        assert_eq!(a, JubJubScalar::zero() + a);
+        let a = Fr::new_random(&mut rng);
+        assert_eq!(a, a + Fr::zero());
+        assert_eq!(a, Fr::zero() + a);
     }
 }
 
@@ -44,9 +37,9 @@ fn test_additive_identity() {
 fn test_subtract_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        assert_eq!(a, a - JubJubScalar::zero());
-        assert_eq!(a, JubJubScalar::zero() - -&a);
+        let a = Fr::new_random(&mut rng);
+        assert_eq!(a, a - Fr::zero());
+        assert_eq!(a, Fr::zero() - -&a);
     }
 }
 
@@ -54,19 +47,20 @@ fn test_subtract_additive_identity() {
 fn test_additive_inverse() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
+        let a = Fr::new_random(&mut rng);
         let a_neg = -&a;
-        assert_eq!(JubJubScalar::zero(), a + a_neg);
-        assert_eq!(JubJubScalar::zero(), a_neg + a);
+        assert_eq!(Fr::zero(), a + a_neg);
+        assert_eq!(Fr::zero(), a_neg + a);
     }
 }
 
+#[allow(clippy::eq_op)]
 #[test]
 fn test_additive_commutativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        let b = JubJubScalar::new_random(&mut rng);
+        let a = Fr::new_random(&mut rng);
+        let b = Fr::new_random(&mut rng);
         assert_eq!(a + b, b + a);
     }
 }
@@ -75,9 +69,9 @@ fn test_additive_commutativity() {
 fn test_multiplicative_associativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        let b = JubJubScalar::new_random(&mut rng);
-        let c = JubJubScalar::new_random(&mut rng);
+        let a = Fr::new_random(&mut rng);
+        let b = Fr::new_random(&mut rng);
+        let c = Fr::new_random(&mut rng);
         assert_eq!((a * b) * c, a * (b * c))
     }
 }
@@ -86,9 +80,9 @@ fn test_multiplicative_associativity() {
 fn test_multiplicative_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        assert_eq!(a, a * JubJubScalar::one());
-        assert_eq!(a, JubJubScalar::one() * a);
+        let a = Fr::new_random(&mut rng);
+        assert_eq!(a, a * Fr::one());
+        assert_eq!(a, Fr::one() * a);
     }
 }
 
@@ -96,13 +90,13 @@ fn test_multiplicative_identity() {
 fn test_multiplicative_inverse() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        if a == JubJubScalar::zero() {
+        let a = Fr::new_random(&mut rng);
+        if a == Fr::zero() {
             continue;
         }
         let a_inv = a.invert().unwrap();
-        assert_eq!(JubJubScalar::one(), a * a_inv);
-        assert_eq!(JubJubScalar::one(), a_inv * a);
+        assert_eq!(Fr::one(), a * a_inv);
+        assert_eq!(Fr::one(), a_inv * a);
     }
 }
 
@@ -110,8 +104,8 @@ fn test_multiplicative_inverse() {
 fn test_multiplicative_commutativity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        let b = JubJubScalar::new_random(&mut rng);
+        let a = Fr::new_random(&mut rng);
+        let b = Fr::new_random(&mut rng);
         assert_eq!(a * b, b * a);
     }
 }
@@ -120,9 +114,9 @@ fn test_multiplicative_commutativity() {
 fn test_multiply_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
-        let a = JubJubScalar::new_random(&mut rng);
-        assert_eq!(JubJubScalar::zero(), JubJubScalar::zero() * a);
-        assert_eq!(JubJubScalar::zero(), a * JubJubScalar::zero());
+        let a = Fr::new_random(&mut rng);
+        assert_eq!(Fr::zero(), Fr::zero() * a);
+        assert_eq!(Fr::zero(), a * Fr::zero());
     }
 }
 
@@ -134,8 +128,8 @@ fn test_dhke() {
         let a = JubJubScalar::new_random(&mut rng);
         let b = JubJubScalar::new_random(&mut rng);
 
-        let a_g = g.mul(&a);
-        let b_g = g.mul(&b);
+        let a_g = g * a;
+        let b_g = g * b;
 
         assert_eq!(dhke(&a, &b_g), dhke(&b, &a_g));
         assert_ne!(dhke(&a, &b_g), dhke(&b, &b_g));


### PR DESCRIPTION
The upstream implementations are taken verbatim, and our own modifications are added in a more segregated manner, for ease of identification.

Resolves: #115, #110