### PR TITLE
feat: add `from_var_bytes` to `Scalar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `from_var_bytes` to scalar [#126]
+
 ## [0.13.1] - 2023-10-11
 
 ### Changed
@@ -198,6 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Initial fork from [`zkcrypto/jubjub`]
 
+[#126]: https://github.com/dusk-network/jubjub/issues/126
 [#115]: https://github.com/dusk-network/jubjub/issues/115
 [#109]: https://github.com/dusk-network/jubjub/issues/109
 [#104]: https://github.com/dusk-network/jubjub/issues/104

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ version = "2"
 default-features = false
 
 # Begin Dusk dependencies
+[dependencies.blake2b_simd]
+version = "1.0"
+default-features = false
+
 [dependencies.bytecheck]
 version = "0.6"
 optional = true
@@ -62,6 +66,7 @@ default-features = false
 [dev-dependencies]
 criterion = "0.3"
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
+quickcheck = "1"
 
 [dev-dependencies.rand_xorshift]
 version = "0.3"


### PR DESCRIPTION
This commit introduces `from_var_bytes` for `Fr`, a function that will take arbitrary slices, hash with BLAKE2b into 256-bit numbers, and perform a modulus multiplication to produce valid scalars.

Such functionality is required for downstream protocols such as Phoenix. They produce arbitrary bytes for off-circuit asymmetric key exchange.