### PR TITLE
Add serde feature

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Nightly tests std
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
-      test_flags: --features=zeroize
+      test_flags: --features=zeroize,serde
 
   test_nightly_no_std:
     name: Nightly tests no_std

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add serde `Serialize` and `Deserialize` implementations for `Fr`, `AffinePoint` and `ExtendedPoint` [#143]
+- Add `serde`, `hex` and `serde_json` optional dependencies [#143]
+- Add `serde` feature [#143]
+
 ## [0.14.1] - 2024-04-24
 
 ### Added
@@ -222,6 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Initial fork from [`zkcrypto/jubjub`]
 
 <!-- ISSUES -->
+[#143]: https://github.com/dusk-network/jubjub/issues/143
 [#137]: https://github.com/dusk-network/jubjub/issues/137
 [#135]: https://github.com/dusk-network/jubjub/issues/135
 [#129]: https://github.com/dusk-network/jubjub/issues/129
@@ -243,6 +250,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#32]: https://github.com/dusk-network/jubjub/issues/32
 [#31]: https://github.com/dusk-network/jubjub/issues/31
 [#25]: https://github.com/dusk-network/jubjub/issues/25
+
 
 <!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/jubjub/compare/v0.14.1...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,18 @@ default-features = false
 version = "1"
 optional = true
 default-features = false
+
+[dependencies.serde]
+version = "1.0"
+optional = true
+
+[dependencies.serde_json]
+version = "1.0"
+optional = true
+
+[dependencies.hex]
+version = "0.4"
+optional = true
 # End Dusk dependendencies
 
 [dev-dependencies]
@@ -81,11 +93,15 @@ default-features = false
 [dev-dependencies.blake2]
 version = "0.9"
 
+[dev-dependencies.rand]
+version = "0.8"
+
 [features]
 default = ["alloc", "bits"]
 alloc = ["ff/alloc", "group/alloc"]
 bits = ["ff/bits"]
 rkyv-impl = ["bytecheck", "dusk-bls12_381/rkyv-impl", "rkyv"]
+serde = ["dep:serde", "serde_json", "hex"]
 
 [[bench]]
 name = "fq_bench"

--- a/src/dusk.rs
+++ b/src/dusk.rs
@@ -7,6 +7,9 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "serde")]
+mod serde_support;
+
 use core::ops::Mul;
 use ff::Field;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};

--- a/src/dusk/serde_support.rs
+++ b/src/dusk/serde_support.rs
@@ -1,0 +1,99 @@
+extern crate alloc;
+
+use alloc::string::{String, ToString};
+
+use dusk_bytes::Serializable;
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{AffinePoint, ExtendedPoint};
+
+impl Serialize for AffinePoint {
+    fn serialize<S: Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let s = hex::encode(self.to_bytes());
+        serializer.serialize_str(&s)
+    }
+}
+
+impl<'de> Deserialize<'de> for AffinePoint {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let decoded = hex::decode(&s).map_err(Error::custom)?;
+        let decoded_len = decoded.len();
+        let bytes: [u8; Self::SIZE] = decoded.try_into().map_err(|_| {
+            Error::invalid_length(decoded_len, &Self::SIZE.to_string().as_str())
+        })?;
+        AffinePoint::from_bytes(bytes)
+            .into_option()
+            .ok_or(Error::custom(
+                "Failed to deserialize AffinePoint: invalid AffinePoint",
+            ))
+    }
+}
+
+impl Serialize for ExtendedPoint {
+    fn serialize<S: Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        AffinePoint::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExtendedPoint {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        AffinePoint::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use group::Group;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    use crate::{AffinePoint, ExtendedPoint};
+
+    #[test]
+    fn serde_affine_point() {
+        let mut rng = StdRng::seed_from_u64(0xdead);
+        let point = ExtendedPoint::random(&mut rng);
+        let point = AffinePoint::from(point);
+        let ser = serde_json::to_string(&point).unwrap();
+        let deser = serde_json::from_str(&ser).unwrap();
+        assert_eq!(point, deser);
+    }
+
+    #[test]
+    fn serde_wrong_encoded() {
+        let wrong_encoded = "wrong-encoded";
+
+        let affine_point: Result<AffinePoint, _> =
+            serde_json::from_str(&wrong_encoded);
+        assert!(affine_point.is_err());
+    }
+
+    #[test]
+    fn serde_too_long_encoded() {
+        let length_33_enc = "\"e4ab9de40283a85d6ea0cd0120500697d8b01c71b7b4b520292252d20937000631\"";
+
+        let affine_point: Result<AffinePoint, _> =
+            serde_json::from_str(&length_33_enc);
+        assert!(affine_point.is_err());
+    }
+
+    #[test]
+    fn serde_too_short_encoded() {
+        let length_31_enc = "\"1751c37a1dca7aa4c048fcc6177194243edc3637bae042e167e4285945e046\"";
+
+        let affine_point: Result<AffinePoint, _> =
+            serde_json::from_str(&length_31_enc);
+        assert!(affine_point.is_err());
+    }
+}


### PR DESCRIPTION
For dusk-network/rusk/issues/2773 and https://github.com/dusk-network/jubjub/issues/143.

~~To serialize `AffineNielsPoint` and `ExtendedNielsPoint`, I implemented `dusk_bytes::Serializable` for them.
But there is currently some uncertainty about the correctness of the approach used to serialize because I don't understand `AffinePoint`'s serialization and I'm unsure about whether or not it will be relevant to `AffineNielsPoint` and `ExtendedNielsPoint`.~~
Edit: `AffineNielsPoint` and `ExtendedNielsPoint` have not being changed.