### PR TITLE
Avoid pulling bitvec into minimal builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,6 @@ exclude = [
     ".gitignore",
 ]
 
-[dependencies.bitvec]
-version = "1"
-default-features = false
-
 [dependencies.dusk-bls12_381]
 version = "0.14"
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-use bitvec::{order::Lsb0, view::AsBits};
 use core::borrow::Borrow;
 use core::fmt;
 use core::iter::Sum;
@@ -322,11 +321,12 @@ impl AffineNielsPoint {
         // We skip the leading four bits because they're always
         // unset for Fr.
         for bit in by
-            .as_bits::<Lsb0>()
             .iter()
             .rev()
+            .flat_map(|byte| {
+                (0..8).rev().map(move |i| Choice::from((byte >> i) & 1u8))
+            })
             .skip(4)
-            .map(|bit| Choice::from(if *bit { 1 } else { 0 }))
         {
             acc = acc.double();
             acc += AffineNielsPoint::conditional_select(&zero, self, bit);


### PR DESCRIPTION
Use the same byte-based bit traversal already used by `ExtendedNielsPoint` and remove the unconditional `bitvec` dependency.

Minimal builds no longer pull in `bitvec` and its four helper crates. The existing `bits` feature still enables `ff/bits`, so users of `PrimeFieldBits` are unchanged.

Affine-Niels multiplication was unchanged in local benchmarks, and cold checks for PLONK, Phoenix, JubJub Schnorr, and Poseidon each resolved five fewer packages.

Closes #160.
